### PR TITLE
Plan PiTTy 0.4.0 welcome, resume, auth, and upgrade

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,18 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with: { fetch-depth: 0 }
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+      - name: Install dependencies
+        run: |
+          npm ci --ignore-scripts --no-audit --no-fund
+          node node_modules/bun/install.js
+      - name: Validate core checks
+        run: |
+          npm run typecheck
+          npm run test:unit
       - name: Validate version
         shell: bash
         run: |

--- a/docs/HANDOFF_0.4.0.md
+++ b/docs/HANDOFF_0.4.0.md
@@ -1,0 +1,418 @@
+# PiTTy 0.4.0 implementation handoff
+
+This document describes the remaining work for the next PiTTy release. The branch `feature/0.4.0-welcome-updates` currently starts from the latest `main` and contains this planning document only. No unfinished application code is hidden on the branch.
+
+## Current baseline
+
+- Public repository: `mistrjirka/PiTTy`
+- Current application version: `0.3.0`
+- Primary platform: Linux / Arch / Konsole
+- CI matrix: Ubuntu, macOS, Windows
+- Pi transport: `pi --mode rpc`
+- Optional integrations:
+  - `npm:pi-subagents`
+  - `npm:@juicesharp/rpiv-todo`
+- Missing optional integrations already degrade gracefully: one informational notification, no crash, and plugin-specific panels remain hidden.
+- The Windows RPC mock-launch issue and the timing-sensitive RPC test have already been fixed on `main`.
+
+## Target release
+
+Use `0.4.0` because the startup flow and executable interface change materially.
+
+The release should add:
+
+1. A welcome screen and resumable-session chooser.
+2. `/resume` inside PiTTy.
+3. `pitty upgrade` and update checks.
+4. Hardened installers and executable installer tests.
+5. Expanded usage documentation and screenshot placeholders.
+
+## 1. Welcome screen and startup session selection
+
+### Required behavior
+
+When PiTTy is launched without `--continue` and without `--session`, it should not immediately drop the user into an empty transcript. Show a welcome screen first.
+
+The welcome screen should contain:
+
+- PiTTy name and one-line description.
+- `New session` action.
+- Recent sessions for the current working directory.
+- Session name when present; otherwise the first user message.
+- Relative modified time and message count.
+- Loading state while session metadata is read.
+- Empty state when no resumable sessions exist.
+- Shortcut hints:
+  - `Ctrl+P` model selector
+  - `Ctrl+T` thinking effort
+  - `Ctrl+S` sidebar
+  - `Ctrl+R` request map once a session is open
+
+Suggested layout:
+
+```text
+PiTTy
+A fast terminal frontend for Pi
+
+[ New session ]
+
+Resume previous work
+  Refactor authentication        8 min ago    42 messages
+  Fix Windows CI                 yesterday    18 messages
+  Initial project review         3 days ago   91 messages
+
+Ctrl+P models   Ctrl+T thinking   Enter select   Esc quit
+```
+
+### Startup rules
+
+- `pitty -c` or `pitty --continue`: skip welcome and continue the newest Pi session.
+- `pitty --session <path|id>`: skip welcome and open that session.
+- No session option: show welcome.
+- Selecting `New session`: start Pi RPC without a session argument.
+- Selecting a session: start Pi RPC with `--session <path>`.
+- Cancelling the welcome screen should exit cleanly without creating a session.
+
+### Recommended implementation
+
+Introduce a root component that owns the startup state instead of mounting `App` directly.
+
+Possible files:
+
+```text
+src/root.tsx
+src/sessions/list.ts
+src/ui/welcome.tsx
+src/ui/session-selector.tsx
+```
+
+Use `SessionManager.list(cwd)` from `@earendil-works/pi-coding-agent` to discover current-project sessions. Do not duplicate Pi's directory encoding or JSONL parsing unless the SDK export becomes unavailable.
+
+Do not spawn the Pi RPC process until the user chooses a session or `New session`. This prevents an unwanted empty session from being created merely by opening PiTTy.
+
+### Acceptance criteria
+
+- Launching plain `pitty` in a project with sessions shows the welcome screen.
+- Launching plain `pitty` in a project without sessions shows a useful empty state.
+- Choosing a session loads the correct transcript.
+- Choosing `New session` opens an empty chat.
+- `--continue` and `--session` retain their existing direct behavior.
+- Keyboard and mouse selection both work.
+
+## 2. In-application session selector and `/resume`
+
+### Required behavior
+
+Add a PiTTy-native `/resume` command. It should open the same session selector used by the welcome screen.
+
+When a session is selected:
+
+1. Ask for confirmation if the current agent is streaming.
+2. Call the RPC `switch_session` command.
+3. Reload `get_state`, `get_messages`, statistics, queues, subagent state, and message-window state.
+4. Return focus to the prompt.
+
+Also add a visible session action in an appropriate menu or status area later; `/resume` is the minimum required interface.
+
+### RPC work
+
+Add to `PiRpcClient`:
+
+```ts
+switchSession(sessionPath: string): Promise<{ cancelled?: boolean }>
+```
+
+The existing `loadCurrentSession()` logic in `src/app.tsx` can be reused after switching.
+
+### Command autocomplete
+
+Add local command metadata:
+
+```text
+/resume  Browse and open another session
+```
+
+Update `/help` and README controls accordingly.
+
+### Acceptance criteria
+
+- `/resume` opens recent current-project sessions.
+- Selecting a session updates the transcript without restarting the terminal application.
+- Cancel leaves the current session unchanged.
+- A failed switch produces a readable toast and does not corrupt the current UI.
+
+## 3. `pitty upgrade`
+
+### Desired command interface
+
+```bash
+pitty upgrade
+pitty upgrade --check
+pitty upgrade --version 0.4.0
+pitty upgrade --with-plugins
+pitty upgrade --without-plugins
+```
+
+`pitty upgrade` should use the same release source and installation paths as the installer.
+
+### Recommended architecture
+
+Do not duplicate the installer logic in JavaScript. Add an installed metadata file, for example:
+
+```text
+<PITTY_INSTALL_DIR>/install.json
+```
+
+Suggested fields:
+
+```json
+{
+  "version": "0.4.0",
+  "repo": "mistrjirka/PiTTy",
+  "installDir": "...",
+  "binDir": "...",
+  "pluginMode": "yes|no|unknown",
+  "installedAt": "ISO timestamp"
+}
+```
+
+The launcher should recognize `upgrade` before starting OpenTUI and invoke the platform installer:
+
+- Linux/macOS/WSL: download `install.sh` to a temporary file, then execute it with explicit paths and options.
+- Windows: download and execute `install.ps1` with explicit paths and options.
+
+Never execute a remote script without first saving it locally. Print the URL and the local temporary path in verbose/error output.
+
+### Upgrade safety
+
+- Download and verify the new archive before touching the current installation.
+- Install into a sibling staging directory.
+- Run a lightweight validation from staging:
+  - package metadata exists
+  - Bun runtime exists
+  - `pitty --help` succeeds
+- Rename the current install to a backup.
+- Move staging into place.
+- Remove backup only after validation.
+- On failure, restore the backup automatically.
+- Never remove user Pi settings, sessions, or optional packages.
+
+### Acceptance criteria
+
+- Upgrading from an older release preserves the launcher and optional Pi packages.
+- Failed dependency installation leaves the previous PiTTy usable.
+- `pitty upgrade --check` changes nothing and returns a useful exit status.
+- Installing an explicit version works even when it is not the latest release.
+
+## 4. Startup update notification
+
+### Required behavior
+
+At startup, PiTTy should check for a newer stable GitHub Release without delaying the UI.
+
+Example toast:
+
+```text
+PiTTy 0.4.1 is available. Run `pitty upgrade`.
+```
+
+### Constraints
+
+- Run asynchronously after the UI mounts.
+- Use a short network timeout, approximately 2–3 seconds.
+- Failure must be silent in the UI and debug-only in logs.
+- Cache the result and check at most once every 24 hours.
+- Do not notify for an equal or older version.
+- Ignore drafts and prereleases by using GitHub's `releases/latest` endpoint.
+- Add a disable mechanism, for example:
+  - `PITTY_NO_UPDATE_CHECK=1`
+  - `--no-update-check`
+
+### Suggested files
+
+```text
+src/update/check.ts
+src/update/version.ts
+test/update.test.ts
+```
+
+Implement a small semver comparator internally or use a lightweight dependency. Do not compare versions lexically.
+
+## 5. Installer hardening
+
+The current installers are usable but need another review before being advertised as broadly cross-platform.
+
+### POSIX `install.sh`
+
+Required improvements:
+
+- Keep all error logs outside the temporary directory so cleanup never deletes diagnostics.
+- Distinguish GitHub API 404, rate limiting, network failure, and missing assets in error text.
+- Verify checksum by default when `SHA256SUMS` exists.
+- Treat a checksum download that succeeds but lacks the selected asset as an error, not only a warning.
+- Add explicit staging/backup/rollback behavior for upgrades and reinstalls.
+- Preserve the prior installation until the new launcher passes validation.
+- Validate that the extracted archive contains `package.json`, `bin/pitty.mjs`, and `src/index.tsx`.
+- Detect a read-only install or bin directory before downloading dependencies.
+- Keep installation unprivileged by default; never suggest `sudo npm install -g` for PiTTy.
+- When `pi` is missing, provide a clear Pi installation hint rather than attempting an implicit privileged install.
+- Make optional plugin failure semantics explicit:
+  - PiTTy installation succeeds.
+  - Return code `2` only when the user explicitly requested strict plugin installation, or document the current behavior prominently.
+
+### Windows `install.ps1`
+
+Important existing issue to fix first:
+
+- `$Temp` is assigned but the directory is not created before `Invoke-WebRequest` writes the archive. Add `New-Item -ItemType Directory -Force -Path $Temp`.
+
+Additional improvements:
+
+- Implement staging/backup/rollback equivalent to POSIX.
+- Validate archive structure before installation.
+- Add the bin directory to the user PATH when approved, or offer a precise command to do it.
+- Avoid machine-wide changes and administrator requirements.
+- Preserve logs after all failures.
+- Test paths containing spaces and non-ASCII characters.
+- Confirm behavior on Windows PowerShell 5.1 and PowerShell 7, or document the supported minimum.
+
+### Uninstallers
+
+- Keep optional packages installed by default.
+- Add an explicit optional flag to remove supported Pi packages.
+- Remove only files owned by PiTTy.
+- Offer removal of the PATH entry on Windows if the installer added it.
+
+## 6. Executable installer tests
+
+The current installer tests only inspect script text. Replace or supplement them with behavior tests.
+
+### POSIX smoke tests
+
+Run the installer against a local fake release server or mocked commands in `PATH`.
+
+Test at least:
+
+- latest release resolution
+- explicit version
+- checksum success
+- checksum mismatch
+- missing archive
+- npm failure with preserved old installation
+- Bun installation failure with preserved old installation
+- paths containing spaces
+- plugin accepted, declined, already installed, and failed
+- `--without-plugins`
+- upgrade rollback
+
+Recommended tools:
+
+- temporary directories
+- fixture archive generated during the test
+- fake `curl`, `npm`, `node`, and `pi` executables
+- no real network access
+
+### Windows smoke tests
+
+Use a PowerShell test script or Pester where practical. At minimum execute the installer in GitHub Actions using mocked commands and a local fixture archive.
+
+### CI improvements
+
+- Keep `sh -n install.sh` and `sh -n uninstall.sh`.
+- Add PowerShell syntax validation.
+- Add installer behavior jobs.
+- Make the Release workflow run typecheck and unit tests before publishing assets, or depend on a reusable validation workflow.
+- Scan release sources and lock files for internal registry URLs.
+
+## 7. Documentation and screenshots
+
+### Usage guide
+
+Expand README or add `docs/USAGE.md` covering:
+
+- startup welcome flow
+- new session vs continue vs resume
+- queue and steering behavior
+- thinking and model controls
+- tool expansion and diffs
+- subagent inspector and steering
+- optional integrations
+- diagnostics and privacy
+- upgrade and uninstall
+
+### Screenshot placeholders
+
+Add these files or references:
+
+```text
+docs/images/welcome-screen.png
+docs/images/main-chat.png
+docs/images/tool-diff.png
+docs/images/model-selector.png
+docs/images/subagent-inspector.png
+```
+
+Actual screenshots from Konsole are preferred over generated mockups because terminal glyph width, colours, and mouse affordances need to match the real application. Add placeholders in README now; replace them with real captures before the public announcement.
+
+Suggested capture settings:
+
+- 1440×900 or similar 16:10 viewport
+- dark terminal theme
+- hide private project paths and prompts
+- use a small public/demo repository
+- include one screenshot with parallel subagents
+
+## 8. OpenSpec changes
+
+Add an OpenSpec change package before implementation:
+
+```text
+openspec/changes/pitty-0.4.0/
+  proposal.md
+  tasks.md
+  specs/
+    welcome-and-sessions/spec.md
+    upgrades/spec.md
+    installer-hardening/spec.md
+```
+
+The task list should map directly to this handoff and be updated as implementation proceeds.
+
+## 9. Suggested implementation order
+
+1. Fix and test the Windows installer temporary-directory bug.
+2. Add installer staging, validation, rollback, and executable smoke tests.
+3. Add update-version utilities and `pitty upgrade --check`.
+4. Add full `pitty upgrade`.
+5. Add the non-blocking startup update notification.
+6. Implement session-listing utilities.
+7. Add the welcome/root component and direct startup rules.
+8. Add `/resume` using RPC `switch_session`.
+9. Add documentation and screenshot placeholders.
+10. Run CI on all platforms and perform real manual tests on Arch/Konsole and Windows Terminal.
+11. Bump to `0.4.0`, update changelog, tag, and publish only after the Release workflow validates the commit.
+
+## 10. Definition of done
+
+The change is ready to merge when:
+
+- TypeScript passes.
+- Unit tests pass on Linux, macOS, and Windows.
+- Installer behavior tests pass without network access.
+- A clean install works on Linux.
+- An upgrade from `0.3.0` preserves a usable previous installation on induced failure.
+- Windows installer creates its temp directory and completes in Windows CI.
+- Plain `pitty` shows welcome without creating an unwanted session.
+- `pitty -c` and `pitty --session` bypass welcome.
+- `/resume` switches sessions correctly.
+- Startup update checks are cached, non-blocking, and suppressible.
+- README includes the new flows and screenshot placeholders.
+- Release assets contain no internal package-registry URLs.
+
+## 11. Known non-goals for 0.4.0
+
+- Recreating Pi's full interactive `/tree` UI.
+- Deleting or renaming sessions from PiTTy.
+- Automatic background installation of updates.
+- Auto-installing Pi with elevated privileges.
+- Reproducing arbitrary direct-TUI extension components that Pi RPC does not serialize.

--- a/docs/HANDOFF_0.4.0.md
+++ b/docs/HANDOFF_0.4.0.md
@@ -17,93 +17,67 @@ This document describes the remaining work for the next PiTTy release. The branc
 
 ## Target release
 
-Use `0.4.0` because the startup flow and executable interface change materially.
+Use `0.4.0` because the chat UI, model-selection workflow, and executable interface change materially.
 
 The release should add:
 
-1. A welcome screen and resumable-session chooser.
+1. Direct chat startup with a refined PiTTy logo empty state; no blocking welcome screen.
 2. `/resume` inside PiTTy.
-3. `pitty upgrade` and update checks.
-4. Hardened installers and executable installer tests.
-5. Expanded usage documentation and screenshot placeholders.
+3. Durable main-chat interaction: focus, draft preservation, non-overlapping command suggestions, global details toggle, thinking layout, and unsupported-login guidance.
+4. Search in the model selector without losing the main draft.
+5. `pitty upgrade` and update checks.
+6. Hardened installers and executable installer tests.
+7. Expanded usage documentation, screenshot placeholders, and repository branding.
 
-## 1. Welcome screen and startup session selection
+## 1. Direct startup and logo empty state
 
 ### Required behavior
 
-When PiTTy is launched without `--continue` and without `--session`, it should not immediately drop the user into an empty transcript. Show a welcome screen first.
+Remove the planned welcome/session-selection screen. Plain `pitty` must start the existing chat UI directly, as it does in 0.3.0; it must not introduce a startup decision, block the prompt, or require a click before typing.
 
-The welcome screen should contain:
+When a directly started session has no rendered conversation items, show a passive, centered PiTTy empty state in the transcript area. It is branding only, not an action surface: the main prompt remains visible, focused, and ready to accept input. Hide the empty state as soon as the first conversation item appears.
 
-- PiTTy name and one-line description.
-- `New session` action.
-- Recent sessions for the current working directory.
-- Session name when present; otherwise the first user message.
-- Relative modified time and message count.
-- Loading state while session metadata is read.
-- Empty state when no resumable sessions exist.
-- Shortcut hints:
-  - `Ctrl+P` model selector
-  - `Ctrl+T` thinking effort
-  - `Ctrl+S` sidebar
-  - `Ctrl+R` request map once a session is open
+### Logo source and terminal treatment
 
-Suggested layout:
-
-```text
-PiTTy
-A fast terminal frontend for Pi
-
-[ New session ]
-
-Resume previous work
-  Refactor authentication        8 min ago    42 messages
-  Fix Windows CI                 yesterday    18 messages
-  Initial project review         3 days ago   91 messages
-
-Ctrl+P models   Ctrl+T thinking   Enter select   Esc quit
-```
+- Commit the supplied source artwork as `docs/images/pitty-tail-icon.svg`. Preserve its title, description, view box, rounded path, and endpoint geometry as the canonical brand asset.
+- Do **not** attempt to render the SVG in OpenTUI. The application is a terminal-cell renderer, not a browser SVG surface.
+- Add a reusable `PittyLogo` terminal component, for example in `src/ui/logo.tsx`, derived from the asset and the supplied `pitty-logo-poc.tsx` reference. Use a compact and a wide layout selected from terminal dimensions.
+- Refine the proof-of-concept away from its Minecraft-like appearance: avoid long `█`/heavy-box straight runs as the primary stroke. Prefer a small, restrained glyph composition with rounded/curved terminal glyphs where supported, two clearly separated square endpoints, one accent color, and a plain `PiTTy` wordmark. Keep every rendered line terminal-cell-width safe.
+- Keep the logo purely decorative: no text input, mouse capture, startup state, or session-management responsibility belongs in the component.
 
 ### Startup rules
 
-- `pitty -c` or `pitty --continue`: skip welcome and continue the newest Pi session.
-- `pitty --session <path|id>`: skip welcome and open that session.
-- No session option: show welcome.
-- Selecting `New session`: start Pi RPC without a session argument.
-- Selecting a session: start Pi RPC with `--session <path>`.
-- Cancelling the welcome screen should exit cleanly without creating a session.
+- `pitty -c` or `pitty --continue`: retain the existing direct-continue behavior.
+- `pitty --session <path|id>`: retain the existing direct-session behavior.
+- No session option: start Pi RPC and open the normal empty chat directly.
+- `/resume` is the only 0.4.0 entry point for browsing and switching existing sessions.
 
 ### Recommended implementation
 
-Introduce a root component that owns the startup state instead of mounting `App` directly.
+Do not add a root/welcome component or defer spawning Pi RPC for a startup choice. Add the logo empty state inside the existing transcript branch of `src/app.tsx`; it must coexist with the existing prompt and message-window behavior.
 
 Possible files:
 
 ```text
-src/root.tsx
-src/sessions/list.ts
-src/ui/welcome.tsx
-src/ui/session-selector.tsx
+src/ui/logo.tsx
+src/app.tsx
+test/render.test.tsx
+docs/images/pitty-tail-icon.svg
 ```
-
-Use `SessionManager.list(cwd)` from `@earendil-works/pi-coding-agent` to discover current-project sessions. Do not duplicate Pi's directory encoding or JSONL parsing unless the SDK export becomes unavailable.
-
-Do not spawn the Pi RPC process until the user chooses a session or `New session`. This prevents an unwanted empty session from being created merely by opening PiTTy.
 
 ### Acceptance criteria
 
-- Launching plain `pitty` in a project with sessions shows the welcome screen.
-- Launching plain `pitty` in a project without sessions shows a useful empty state.
-- Choosing a session loads the correct transcript.
-- Choosing `New session` opens an empty chat.
+- Plain `pitty` reaches a focused, writable main prompt without an intermediate welcome screen.
 - `--continue` and `--session` retain their existing direct behavior.
-- Keyboard and mouse selection both work.
+- A new/empty conversation shows the refined PiTTy logo; the first conversation item removes it.
+- The logo is legible at supported terminal sizes and does not cause horizontal overflow, clipping, or focus loss.
+- The committed SVG is the canonical repository asset, even though the terminal view renders the glyph component.
 
 ## 2. In-application session selector and `/resume`
 
 ### Required behavior
 
-Add a PiTTy-native `/resume` command. It should open the same session selector used by the welcome screen.
+Add a PiTTy-native `/resume` command. It should open a standalone current-project session selector; it is no longer part of startup.
 
 When a session is selected:
 
@@ -134,6 +108,12 @@ Add local command metadata:
 
 Update `/help` and README controls accordingly.
 
+### Command capability boundary
+
+Continue merging local commands with the runtime `get_commands` response for Pi extension commands, prompt templates, and skills. Treat that response as authoritative for remote command availability. Pi's RPC protocol does not expose interactive built-in commands such as `/login`; do not imply full direct-TUI parity.
+
+Add `/login` as a local autocomplete entry whose only behavior is the approved guidance to run `pi` and use `/login` there. It must never forward the command as a normal prompt, open an API-key/OAuth UI, read or write credentials, or log secrets. Native login is explicitly deferred beyond 0.4.0.
+
 ### Acceptance criteria
 
 - `/resume` opens recent current-project sessions.
@@ -141,7 +121,86 @@ Update `/help` and README controls accordingly.
 - Cancel leaves the current session unchanged.
 - A failed switch produces a readable toast and does not corrupt the current UI.
 
-## 3. `pitty upgrade`
+## 3. Main-chat focus after mouse interaction
+
+### Problem
+
+The prompt receives keyboard input on initial launch, but clicking elsewhere can leave it unfocused. Subsequent typing then does not reach the main chat textarea. Existing explicit `prompt.focus()` calls cover startup and some dialog-close paths, but not the general mouse interaction path.
+
+The model selector can also visually obscure the lower prompt on short terminals. Current evidence does not prove that it clears the textarea buffer, so a regression test must distinguish actual draft loss from visual occlusion before adding a restore workaround.
+
+### Required behavior
+
+- While no modal, model selector, prompt map, or subagent-inspector editor owns focus, keyboard text must go to the main chat textarea after any non-interactive transcript-area click.
+- Clicking an interactive control must preserve that control's action; focus the prompt only after its action completes when that control does not intentionally own text input.
+- Do not steal focus from extension input/editor dialogs, the model search field, or the subagent steering textarea.
+- Existing close, cancel, selection, and `/resume` paths must still return focus to the main prompt.
+- Opening, closing, or selecting a model must not submit, queue, replace, or clear an unsent main-prompt draft.
+- Command suggestions must remain in layout flow above the prompt, be bounded for the terminal height, and never overlap or hide the prompt editor.
+- `Ctrl+O` is a global details toggle: if tools or thinking are open, collapse both and reset individual overrides; only when both are collapsed, expand both.
+- A thinking-only assistant panel must begin directly beside its cyan left border without a dark gutter.
+- `/login` must be locally intercepted. Display: `Sorry, login is not supported in PiTTy yet. Run pi and use /login there; your credentials will then be available to PiTTy.` Do not forward it through RPC or handle credentials.
+
+### Recommended implementation and validation
+
+Centralize the policy in one named `focusMainPrompt()` helper in `src/app.tsx`, scheduled after the click/action so OpenTUI has completed its own pointer focus processing. Apply it at the transcript/background click boundary and reuse it from existing close paths rather than sprinkling new direct `prompt?.focus()` calls. Keep modal ownership checks in that helper or at its callers.
+
+Add a render-level regression test that starts the app or a focused prompt harness, clicks a non-input transcript/background target using OpenTUI's mouse test support, then sends text and asserts that the prompt receives it. Cover a representative clickable transcript control and a modal/text-input exception. Add a model-selector test with a populated draft that checks textarea identity and content both while the modal is open and after it closes; test short terminal geometry separately. Add visual tests for bounded suggestions and a thinking-only row.
+
+### Acceptance criteria
+
+- Typing works immediately on launch and after clicking a non-input part of the main chat.
+- Clicking a transcript action still performs that action and leaves the prompt ready for the next input when appropriate.
+- Modal and secondary editor focus is not stolen.
+- Opening or closing the model selector preserves an unsent draft and returns focus after close.
+- Command suggestions do not overlap or hide a writable prompt in a constrained terminal.
+- Ctrl+O globally collapses or expands both tool and thinking detail as specified.
+- A thinking-only panel has no dark left gutter, and `/login` displays local Pi CLI guidance without an RPC prompt.
+- The regression test fails without the focus-routing fix.
+
+## 4. Searchable model selector
+
+### Required behavior
+
+Add a focused search textarea to the `Ctrl+P` model selector. It filters the already fetched, normalized model list locally as the user types; it must not issue another RPC request per keystroke.
+
+- Match case-insensitively against provider, model id, and display name.
+- Preserve the existing provider/id sort order within the filtered result.
+- Reset selection to the first matching model when the query changes.
+- Display the matched count and an explicit empty state. In the empty state, Enter must not select a stale model.
+- `Esc` closes the selector and returns focus to the unchanged main prompt draft. Selecting a model retains the existing RPC behavior and also returns focus without submitting or clearing that draft.
+- Mouse selection, arrow navigation, and Enter selection remain usable with the search field present.
+
+### Recommended implementation and validation
+
+Extend `src/ui/model-selector.tsx` rather than creating a second model-list abstraction. Export a small pure filtering helper with the existing `ModelChoice` type, then make the dialog own only the query and focus coordination. Update `src/app.tsx` only for dialog focus/close integration.
+
+Add focused tests for provider/id/name matches, case insensitivity, no matches, and the rendered search/empty state. Extend the existing model selector render test for keyboard/mouse behavior if the OpenTUI harness supports it.
+
+### Acceptance criteria
+
+- A user can narrow a large model list by typing provider, id, or name.
+- Clearing the query restores all normalized choices in the existing order.
+- No match cannot select the prior model.
+- Closing or selecting returns keyboard input to the main prompt.
+
+## 5. Repository branding on GitHub
+
+### Required behavior and constraint
+
+Use the committed SVG as PiTTy's canonical branding asset and add it to the README or usage documentation where GitHub can render it. A GitHub repository itself has no independent avatar/logo setting: its visible avatar is the owner account or organization avatar. Do not change the `mistrjirka` account avatar as part of this release without separate, explicit approval because it affects every repository owned by that account.
+
+Configure the repository's social-preview image manually in GitHub **repository Settings → Social preview → Edit** using a raster export of the canonical SVG. GitHub recommends a PNG, JPG, or GIF under 1 MB and at least 640×320 (ideally 1280×640), so use a social-card composition rather than the raw square icon. The installed `gh repo edit` command has no logo or social-preview flag; do not rely on an undocumented `gh api` call.
+
+This environment's `gh` session is currently unauthenticated, so no GitHub settings can be changed until the repository owner runs `gh auth login` (or supplies a suitable `GH_TOKEN`) and approves the scope. Treat that as release-preparation work, not a code-path blocker.
+
+### Acceptance criteria
+
+- The SVG is committed and displayed from repository content in GitHub-rendered documentation.
+- A maintainer has configured and visually checked the social preview before the public announcement.
+- The personal-account avatar is unchanged unless separately approved.
+
+## 6. `pitty upgrade`
 
 ### Desired command interface
 
@@ -204,7 +263,7 @@ Never execute a remote script without first saving it locally. Print the URL and
 - `pitty upgrade --check` changes nothing and returns a useful exit status.
 - Installing an explicit version works even when it is not the latest release.
 
-## 4. Startup update notification
+## 7. Startup update notification
 
 ### Required behavior
 
@@ -238,7 +297,7 @@ test/update.test.ts
 
 Implement a small semver comparator internally or use a lightweight dependency. Do not compare versions lexically.
 
-## 5. Installer hardening
+## 8. Installer hardening
 
 The current installers are usable but need another review before being advertised as broadly cross-platform.
 
@@ -283,7 +342,7 @@ Additional improvements:
 - Remove only files owned by PiTTy.
 - Offer removal of the PATH entry on Windows if the installer added it.
 
-## 6. Executable installer tests
+## 9. Executable installer tests
 
 The current installer tests only inspect script text. Replace or supplement them with behavior tests.
 
@@ -324,14 +383,14 @@ Use a PowerShell test script or Pester where practical. At minimum execute the i
 - Make the Release workflow run typecheck and unit tests before publishing assets, or depend on a reusable validation workflow.
 - Scan release sources and lock files for internal registry URLs.
 
-## 7. Documentation and screenshots
+## 10. Documentation, screenshots, and repository branding
 
 ### Usage guide
 
 Expand README or add `docs/USAGE.md` covering:
 
-- startup welcome flow
-- new session vs continue vs resume
+- direct startup and the logo empty state
+- continue vs `/resume`
 - queue and steering behavior
 - thinking and model controls
 - tool expansion and diffs
@@ -345,7 +404,7 @@ Expand README or add `docs/USAGE.md` covering:
 Add these files or references:
 
 ```text
-docs/images/welcome-screen.png
+docs/images/empty-chat-logo.png
 docs/images/main-chat.png
 docs/images/tool-diff.png
 docs/images/model-selector.png
@@ -362,37 +421,40 @@ Suggested capture settings:
 - use a small public/demo repository
 - include one screenshot with parallel subagents
 
-## 8. OpenSpec changes
+## 11. OpenSpec changes
 
 Add an OpenSpec change package before implementation:
 
 ```text
-openspec/changes/pitty-0.4.0/
+openspec/changes/pitty-v040/
   proposal.md
   tasks.md
   specs/
-    welcome-and-sessions/spec.md
+    branding-and-sessions/spec.md
+    chat-input-focus/spec.md
+    model-selector-search/spec.md
     upgrades/spec.md
     installer-hardening/spec.md
 ```
 
 The task list should map directly to this handoff and be updated as implementation proceeds.
 
-## 9. Suggested implementation order
+## 12. Suggested implementation order
 
 1. Fix and test the Windows installer temporary-directory bug.
 2. Add installer staging, validation, rollback, and executable smoke tests.
 3. Add update-version utilities and `pitty upgrade --check`.
 4. Add full `pitty upgrade`.
 5. Add the non-blocking startup update notification.
-6. Implement session-listing utilities.
-7. Add the welcome/root component and direct startup rules.
-8. Add `/resume` using RPC `switch_session`.
-9. Add documentation and screenshot placeholders.
-10. Run CI on all platforms and perform real manual tests on Arch/Konsole and Windows Terminal.
-11. Bump to `0.4.0`, update changelog, tag, and publish only after the Release workflow validates the commit.
+6. Implement session-listing utilities and `/resume` using RPC `switch_session`.
+7. Commit the canonical SVG, implement the refined terminal logo empty state, and keep direct startup unchanged.
+8. Fix and regression-test main-chat focus, draft preservation, bounded command suggestions, global Ctrl+O detail controls, thinking-only alignment, and local `/login` guidance.
+9. Add and test model-selector search without draft loss or stale selection.
+10. Add documentation and screenshot placeholders; configure and verify GitHub social preview after authenticating `gh` or through repository Settings.
+11. Run CI on all platforms and perform real manual tests on Arch/Konsole and Windows Terminal.
+12. Bump to `0.4.0`, update changelog, tag, and publish only after the Release workflow validates the commit.
 
-## 10. Definition of done
+## 13. Definition of done
 
 The change is ready to merge when:
 
@@ -402,17 +464,22 @@ The change is ready to merge when:
 - A clean install works on Linux.
 - An upgrade from `0.3.0` preserves a usable previous installation on induced failure.
 - Windows installer creates its temp directory and completes in Windows CI.
-- Plain `pitty` shows welcome without creating an unwanted session.
-- `pitty -c` and `pitty --session` bypass welcome.
+- Plain `pitty` opens the direct chat with a focused prompt and the logo empty state; it has no welcome screen.
+- `pitty -c` and `pitty --session` retain direct behavior.
 - `/resume` switches sessions correctly.
+- A click in the main chat does not strand keyboard input outside the prompt; modal/editor exceptions retain their own focus.
+- Opening, closing, or selecting from the model selector preserves an unsent draft; command suggestions never overlap the prompt.
+- Ctrl+O is a global tool-and-thinking details toggle, thinking-only panels have no dark left gutter, and `/login` gives local Pi CLI guidance without credential handling.
+- The model selector filters locally by provider, id, and name without stale selection.
 - Startup update checks are cached, non-blocking, and suppressible.
-- README includes the new flows and screenshot placeholders.
+- README includes the new flows, canonical logo, and screenshot placeholders; a maintainer has verified the GitHub social preview.
 - Release assets contain no internal package-registry URLs.
 
-## 11. Known non-goals for 0.4.0
+## 14. Known non-goals for 0.4.0
 
 - Recreating Pi's full interactive `/tree` UI.
 - Deleting or renaming sessions from PiTTy.
 - Automatic background installation of updates.
 - Auto-installing Pi with elevated privileges.
+- Changing the `mistrjirka` account avatar as repository branding.
 - Reproducing arbitrary direct-TUI extension components that Pi RPC does not serialize.

--- a/docs/IMPLEMENT_0.4.0_PROMPT.md
+++ b/docs/IMPLEMENT_0.4.0_PROMPT.md
@@ -1,0 +1,543 @@
+# Implementer prompt: finish PiTTy 0.4.0
+
+You are implementing PiTTy 0.4.0 in `mistrjirka/PiTTy`.
+
+Work only on branch:
+
+```text
+feature/0.4.0-welcome-updates
+```
+
+A draft pull request already exists from that branch to `main`. Do not commit directly to `main`, merge the pull request, create a release, or move tags. Complete the implementation on the feature branch, run the full validation suite, and leave the PR ready for human review.
+
+## Read first
+
+Before changing code, read these files completely:
+
+```text
+docs/HANDOFF_0.4.0.md
+openspec/project.md
+openspec/specs/core-rpc-ui/spec.md
+openspec/specs/optional-integrations/spec.md
+openspec/specs/installers/spec.md
+openspec/specs/plugin-compatibility/spec.md
+README.md
+CONTRIBUTING.md
+```
+
+Inspect the exact exported API of the installed `@earendil-works/pi-coding-agent` version before relying on an import. Prefer supported public exports. Do not copy Pi credentials or reimplement provider-specific OAuth protocols.
+
+## Goal
+
+Finish PiTTy 0.4.0 as a coherent release containing:
+
+1. A welcome screen shown when no session was explicitly selected.
+2. Current-project session discovery and resume selection.
+3. A PiTTy-native `/resume` flow.
+4. Provider connection management with `/login`, `/logout`, and `/providers`.
+5. A `Connect provider` action on the welcome screen.
+6. `pitty upgrade` with safe rollback.
+7. A non-blocking startup notification when a newer stable PiTTy release exists.
+8. Hardened POSIX and Windows installers.
+9. Executable installer smoke tests rather than string-only tests.
+10. Updated OpenSpec, README usage documentation, changelog, and screenshot placeholders.
+
+The result must continue to work when `pi-subagents` and `@juicesharp/rpiv-todo` are absent. Missing optional integrations must never crash startup.
+
+## Non-negotiable constraints
+
+- Preserve Pi authentication, sessions, models, tools, extensions, skills, prompt templates, and settings.
+- Keep Pi as the agent backend. Do not replace the current RPC architecture in this release.
+- Keep generic rendering for unknown tools and extensions.
+- Do not expose credentials in transcripts, toasts, errors, diagnostics, process arguments, shell history, or test snapshots.
+- Do not log API keys, OAuth codes, access tokens, refresh tokens, authorization headers, or full auth callback URLs containing secrets.
+- Never write secrets into Solid signals that are retained longer than the active prompt requires.
+- Secret input must be masked.
+- Authentication cancellation must abort pending network work.
+- Do not require root, `sudo`, administrator mode, or machine-wide installation.
+- Do not run real provider logins or access real user credentials in tests.
+- Do not make release checking or installer tests depend on the public internet.
+- Keep Linux, macOS, Windows, and WSL in scope.
+- Preserve current CLI compatibility unless an explicit replacement is documented and tested.
+- Do not remove the existing `--continue`, `--session`, `--model`, `--provider`, `--thinking`, or diagnostic options.
+
+## Phase 0: baseline and version source
+
+1. Pull the latest `main` into the feature branch without discarding branch work.
+2. Run the current baseline:
+
+```bash
+npm ci --ignore-scripts --no-audit --no-fund
+node node_modules/bun/install.js
+npm run typecheck
+npm run test:unit
+```
+
+3. Record existing failures before changing code.
+4. Introduce one canonical application version source. Avoid separately hardcoding the version in `package.json`, `src/index.tsx`, update checks, and UI labels.
+5. Bump the release version to `0.4.0` in all required package/lock metadata.
+6. Add or update OpenSpec change material for the complete 0.4.0 scope before implementation.
+
+## Phase 1: startup root and welcome screen
+
+### Startup behavior
+
+When launched with neither `--continue` nor `--session`, PiTTy must show a welcome screen before starting a normal empty Pi RPC session.
+
+Rules:
+
+- `pitty -c` or `pitty --continue`: skip welcome and continue the newest session.
+- `pitty --session <path|id>`: skip welcome and open that session.
+- No session option: show welcome.
+- Selecting `New session`: start a new persistent Pi session.
+- Selecting a previous session: start Pi with `--session <path>` or switch through RPC after startup, whichever produces the cleaner and more reliable architecture.
+- Cancelling the welcome screen exits cleanly without creating a session.
+
+### Session discovery
+
+Use Pi's supported session APIs, preferably `SessionManager.list(cwd)`, rather than reverse-engineering Pi's encoded session directory manually.
+
+Show only sessions applicable to the current working directory by default. Each row should include:
+
+- session name when present
+- otherwise a normalized preview of the first user message
+- relative modified time
+- message count
+- optional short session ID as secondary information
+
+The screen needs:
+
+- loading state
+- empty state
+- readable error state
+- keyboard navigation
+- mouse selection
+- selected-row highlight
+- `Enter` to open
+- `Esc` to exit
+- a visible `New session` action
+- a visible `Connect provider` action
+
+Suggested layout:
+
+```text
+PiTTy
+A fast terminal frontend for Pi
+
+[ New session ]   [ Connect provider ]
+
+Resume previous work
+  Refactor authentication       8 min ago      42 messages
+  Fix Windows CI                yesterday      18 messages
+  Initial project review        3 days ago     91 messages
+
+Ctrl+P models   Ctrl+T thinking   Enter select   Esc quit
+```
+
+Do not start background subagent artifact polling while the welcome screen is active.
+
+### Startup model and thinking controls
+
+`Ctrl+P` on the welcome screen should open a model selector backed by the same Pi model catalog/auth state used for provider management. A selected startup model must be passed to the Pi RPC process when the user starts or resumes a session.
+
+`Ctrl+T` should cycle the startup thinking level and show the current value before the session starts.
+
+If loading the model runtime fails, the user must still be able to start Pi with its normal defaults.
+
+## Phase 2: PiTTy-native session resume
+
+Add `/resume` to local command choices and help.
+
+Required behavior:
+
+- `/resume` opens the same current-project session selector used by the welcome screen.
+- It must work from an active PiTTy session.
+- Refuse or ask for confirmation when the current session is streaming or has pending local follow-ups.
+- Use Pi RPC `switch_session` with the selected absolute session path.
+- After switching, reload messages, state, stats, session name, model, thinking level, queues, windowing state, and subagent context.
+- Reset inspector/dialog state that belongs to the prior session.
+- Do not leave stale transcript items from the previous session.
+- If an extension cancels the switch, preserve the current session and report that the switch was cancelled.
+- Add a shortcut for the resume selector only when it does not conflict with existing terminal conventions. Document it if added.
+
+Add a typed `switchSession(sessionPath)` method to `PiRpcClient` rather than sending an untyped raw command from the UI.
+
+## Phase 3: provider connection and authentication
+
+### Why this must be implemented outside current Pi RPC
+
+Pi's native `/login` and `/logout` are built-in interactive-mode commands. Current Pi RPC exposes no login/logout/auth-status command, and `get_commands` does not include built-in TUI commands. PiTTy therefore must use Pi's public authentication/model runtime API directly for this release.
+
+Do not send `/login` as a normal RPC prompt and pretend it is supported.
+
+### Required commands and entry points
+
+Implement:
+
+```text
+/providers
+/login
+/login <provider-id>
+/logout
+/logout <provider-id>
+```
+
+Also expose `Connect provider` on the welcome screen. In an active session, the provider manager should be reachable from `/providers` and `/login`.
+
+### Runtime integration
+
+Use Pi's public model/auth APIs where available, centered around `ModelRuntime` and its supported provider/auth methods. Inspect the exact installed package exports first.
+
+Expected capabilities include equivalents of:
+
+- provider enumeration
+- provider auth capabilities (`api_key`, `oauth`, or both)
+- `getProviderAuthStatus(providerId)`
+- `listCredentials()`
+- `login(providerId, authType, interaction)`
+- `logout(providerId)`
+- runtime/model refresh after auth changes
+
+Do not directly edit `~/.pi/agent/auth.json` except through Pi's credential storage/runtime APIs.
+
+Respect Pi profile and agent-directory overrides such as `PI_CODING_AGENT_DIR` and `PI_PROFILE` by relying on Pi's own config helpers/defaults rather than constructing `~/.pi/agent` paths manually.
+
+### Provider manager UI
+
+Show a searchable list with:
+
+- provider display name
+- provider ID
+- authentication methods supported
+- status: connected/stored, environment, runtime, or not configured
+- number of currently available models when inexpensive to calculate
+
+Example:
+
+```text
+Connect provider
+
+  ChatGPT Plus/Pro (Codex)      OAuth       Not connected
+  Claude Pro/Max                OAuth       Connected
+  GitHub Copilot                OAuth       Not connected
+  OpenRouter                    API key     Environment
+  OpenCode Go                   API key     Stored
+```
+
+Provider names and capabilities must come from Pi's provider definitions rather than a hardcoded four-provider allowlist. A provider without interactive login support may be displayed as ambient/config-only with clear instructions instead of a broken login action.
+
+### Auth interaction UI
+
+Implement Pi's authentication interaction contract completely.
+
+Supported prompt types:
+
+- `text`
+- `secret`
+- `select`
+- `manual_code`
+
+Supported notification/event types:
+
+- informational text and links
+- authorization URL
+- device code with verification URI, expiry and polling status
+- progress messages
+
+Requirements:
+
+- `secret` is masked and never copied into transcript/history/logging.
+- `manual_code` supports callback-code fallback flows.
+- `select` uses a proper list selector.
+- Authorization URLs are selectable/copyable.
+- Attempting to open the system browser is optional convenience, never required for completion.
+- Device codes are clearly separated from ordinary text and easy to copy.
+- A cancel action aborts the whole login with `AbortController`.
+- Per-prompt abort signals are respected.
+- Progress replaces or updates one auth status region instead of flooding the transcript.
+- Auth UI is modal and cannot accidentally submit its contents as an agent prompt.
+
+### Refreshing the running Pi process
+
+Writing credentials through a separate `ModelRuntime` instance does not guarantee that the already-running RPC process reloads its in-memory credential/model state.
+
+Implement an explicit, safe refresh strategy:
+
+- Before login/logout during an active session, require Pi to be idle.
+- Capture the active session file/path and startup arguments.
+- Complete the login/logout through Pi's auth API.
+- Restart the Pi RPC child against the same session file when required so the provider/model catalog and credentials are reloaded.
+- Rehydrate the UI exactly as after normal startup.
+- Preserve the current session and unsent editor text.
+- Never restart while a tool or model response is running.
+- If restart fails, show a clear recovery message and retain the credential change; do not corrupt the session.
+
+When on the welcome screen, simply refresh the startup model/provider state after login without starting an agent session.
+
+### Logout behavior
+
+- `/logout` without an argument opens the provider selector filtered to connected/stored providers.
+- Ask for confirmation.
+- Remove only the selected provider credential through Pi's API.
+- Environment-provided credentials cannot be deleted by PiTTy; explain that the environment variable must be removed instead.
+- Refresh/restart as described above.
+
+### Authentication tests
+
+Use a fake provider/runtime. Test:
+
+- provider status rendering
+- API-key login
+- OAuth URL flow
+- device-code flow
+- manual-code flow
+- select prompt
+- cancellation
+- per-prompt cancellation
+- logout confirmation
+- ambient credential behavior
+- auth failure and retry
+- no secret content in logs, transcript items, thrown error snapshots, or diagnostic bundles
+- RPC restart/reload after auth mutation
+
+No test may contact a real provider.
+
+## Phase 4: update checks and `pitty upgrade`
+
+### Startup update notification
+
+After the main UI or welcome screen mounts, check asynchronously for a newer stable GitHub Release.
+
+Requirements:
+
+- never block startup
+- use `releases/latest`
+- ignore drafts/prereleases naturally through that endpoint
+- timeout in roughly 2–3 seconds
+- cache the check for 24 hours
+- semantic version comparison, not lexical comparison
+- no toast when current version is equal or newer
+- network/API failure is silent in UI and debug-only in diagnostics
+- support `PITTY_NO_UPDATE_CHECK=1`
+- add `--no-update-check`
+
+Example notification:
+
+```text
+PiTTy 0.4.1 is available. Run `pitty upgrade`.
+```
+
+### Upgrade commands
+
+Implement at least:
+
+```text
+pitty upgrade
+pitty upgrade --check
+pitty upgrade --version 0.4.0
+pitty --version
+```
+
+Prefer handling launcher-level subcommands in `bin/pitty.mjs` before starting OpenTUI.
+
+`upgrade --check` must not mutate files. Define and document useful exit codes.
+
+Use the installer belonging to the currently installed PiTTy release or shared local upgrade logic. Do not pipe an uninspected remote shell script directly into a shell. Preserve configured install/bin paths.
+
+Upgrade default behavior must not reinstall, remove, or change optional Pi packages. Provide an explicit option when the user wants plugin reconciliation.
+
+## Phase 5: installer hardening
+
+### Shared safety model
+
+Both installers must:
+
+1. Resolve/download the requested release.
+2. Download checksums.
+3. Verify the selected asset strictly when checksum data exists.
+4. Extract to a temporary location.
+5. Validate required files:
+   - `package.json`
+   - `package-lock.json`
+   - `bin/pitty.mjs`
+   - `src/index.tsx`
+6. Install dependencies into a sibling staging directory.
+7. Install the local Bun runtime.
+8. Validate staging with at least `pitty --help`.
+9. Rename the old installation to a backup.
+10. Move staging into place.
+11. Validate the installed launcher.
+12. Remove the backup only after success.
+13. Restore the backup automatically on any post-swap failure.
+
+Never remove Pi settings, credentials, sessions, or optional Pi packages during an upgrade.
+
+### POSIX installer
+
+Fix and test:
+
+- useful errors for release 404, rate limit, transport failure and missing asset
+- logs outside temporary cleanup paths
+- strict checksum asset matching
+- spaces/non-ASCII paths
+- read-only install/bin directory detection
+- rollback on npm, Bun, validation and move failure
+- no `sudo`
+- a clear unprivileged Pi installation hint when `pi` is missing
+
+Optional plugin installation failures must be readable but nonfatal by default because PiTTy works without those packages. Preserve compatibility with the existing plugin-related flags; add a clearly named strict mode if a nonzero exit is desired.
+
+### Windows installer
+
+Fix the existing bug first: create `$Temp` before downloading into it.
+
+Also implement/test:
+
+- staging/backup/rollback equivalent to POSIX
+- strict archive validation
+- persistent logs
+- paths with spaces/non-ASCII characters
+- current-user PATH offer/removal without administrator rights
+- Windows PowerShell 5.1 and PowerShell 7 compatibility, or explicitly document a narrower supported minimum
+- plugin failures nonfatal by default
+
+### Uninstallers
+
+- remove only PiTTy-owned files
+- keep optional Pi packages by default
+- explicit option to remove supported optional packages
+- Windows can remove only the PATH entry that PiTTy previously added
+
+## Phase 6: executable installer tests and CI
+
+Replace/supplement string-presence installer tests with real behavior tests using temporary directories and mocked commands/local fixtures.
+
+Do not use the public network.
+
+POSIX cases:
+
+- latest release
+- explicit version
+- checksum success and mismatch
+- missing asset
+- malformed archive
+- npm failure rollback
+- Bun failure rollback
+- staging validation failure rollback
+- paths with spaces
+- plugin accepted/declined/already installed/failed
+- upgrade preserves old install on failure
+
+Windows cases:
+
+- temporary directory creation
+- ZIP extraction and validation
+- rollback
+- user PATH handling
+- plugin behavior
+- paths with spaces
+
+CI requirements:
+
+- Ubuntu, macOS and Windows typecheck/unit tests
+- shell syntax checks
+- PowerShell syntax check
+- installer smoke-test jobs
+- release workflow validates typecheck/unit tests before publishing assets
+- release source/lock scan for internal registry URLs or private package hosts
+
+Keep the OpenTUI native cleanup caveat isolated from deterministic core/installer tests. A flaky native renderer cleanup must not hide failures in auth, sessions, updates or installer logic.
+
+## Phase 7: documentation and screenshots
+
+Update README with:
+
+- concise product description
+- install instructions for Linux/macOS/WSL and Windows
+- first-run welcome/session behavior
+- provider connection guide
+- `/login`, `/logout`, `/providers`, `/resume`
+- model/thinking shortcuts
+- `pitty upgrade` and update-check controls
+- optional integrations and graceful fallback
+- troubleshooting for Pi missing, PATH, GitHub release errors and installer log locations
+- uninstallation
+
+Create screenshot placeholders without claiming they are real screenshots:
+
+```text
+docs/images/welcome-screen.png
+docs/images/main-chat.png
+docs/images/model-selector.png
+docs/images/provider-login.png
+docs/images/subagent-inspector.png
+```
+
+Until real captures exist, use a `docs/images/README.md` capture checklist and HTML comments in the main README rather than broken image links. Real terminal screenshots should be captured later from PiTTy itself; do not generate misleading mock screenshots and present them as authentic.
+
+Update:
+
+- `CHANGELOG.md`
+- OpenSpec specs/change records
+- `docs/HANDOFF_0.4.0.md` to mark implemented items and retain only genuine follow-ups
+- CLI help
+- command autocomplete/help output
+
+## Required validation
+
+Run from a clean checkout of the feature branch:
+
+```bash
+npm ci --ignore-scripts --no-audit --no-fund
+node node_modules/bun/install.js
+npm run typecheck
+npm run test:unit
+```
+
+Also run:
+
+- targeted auth tests
+- targeted session/welcome tests
+- targeted update/version tests
+- POSIX installer smoke tests
+- Windows installer smoke tests in CI or an appropriate Windows environment
+- `sh -n install.sh uninstall.sh`
+- PowerShell parser/syntax validation
+- manual Linux smoke test of welcome, resume, provider list and a non-secret mock auth flow
+
+Do not claim Windows/macOS behavior was manually verified unless it actually was. Distinguish CI validation from real terminal testing.
+
+## Definition of done
+
+The branch is ready for review only when all of these are true:
+
+- No explicit session option opens the welcome screen.
+- `--continue` and `--session` bypass it.
+- Sessions for the current project are selectable.
+- `/resume` switches sessions without stale UI state.
+- `/providers`, `/login`, and `/logout` work through Pi's auth APIs.
+- OAuth/API-key prompts are complete and cancellable.
+- Secrets never enter transcript or diagnostics.
+- Auth changes are visible to the running Pi process through a tested refresh/restart strategy.
+- `pitty upgrade --check` is non-mutating.
+- `pitty upgrade` is rollback-safe.
+- New-release notification is asynchronous and cached.
+- Both installers preserve a working old installation after failure.
+- Optional plugins remain optional and failures are readable/nonfatal by default.
+- Real installer behavior tests exist.
+- README/OpenSpec/changelog are current.
+- Version is consistently `0.4.0`.
+- TypeScript and all deterministic tests pass.
+
+## Final response expected from the implementer
+
+When finished, provide:
+
+1. A concise architecture summary.
+2. Exact files changed.
+3. Commands/tests run and their results.
+4. Platform validation matrix distinguishing CI from manual testing.
+5. Security review focused on credentials and updater execution.
+6. Remaining known limitations.
+7. Any upstream Pi RPC feature request that would simplify future auth support.
+8. Confirmation that no tag, release, merge or direct `main` push was performed.

--- a/openspec/changes/pitty-v040/.openspec.yaml
+++ b/openspec/changes/pitty-v040/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-15

--- a/openspec/changes/pitty-v040/design.md
+++ b/openspec/changes/pitty-v040/design.md
@@ -1,0 +1,83 @@
+## Context
+
+PiTTy is a Solid/OpenTUI terminal frontend that launches Pi in RPC mode. Pi owns agent execution, sessions, models, provider credentials, extension commands, prompt templates, and skills. The current application already has a stable main textarea, transcript renderer, model selector, RPC command client, installer scripts, and bounded render tests.
+
+The 0.4.0 handoff originally proposed a blocking welcome screen. The accepted direction keeps direct chat startup and uses branding only as an empty transcript state. The same release also combines several interaction fixes in the shared `App`/UI control layer and expands release/install safety.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Preserve Pi as the source of truth while making its documented RPC surface discoverable and usable in PiTTy.
+- Keep the main prompt visible, focused when appropriate, and draft-safe during transient UI states.
+- Make detail expansion and model selection predictable on mouse and keyboard.
+- Make upgrades and reinstallations atomic from the user's perspective.
+- Use the supplied logo as the canonical repository asset and a terminal-safe visual source.
+
+**Non-Goals:**
+
+- Reproduce Pi's direct interactive TUI or its private component APIs.
+- Implement PiTTy-owned API-key entry, OAuth, browser login, credential persistence, or `/logout`.
+- Forward unsupported built-in commands such as `/login` to Pi RPC.
+- Add a startup session chooser or require a startup click before typing.
+
+## Decisions
+
+### Keep direct startup; render branding as a passive empty state
+
+The existing `App` continues to start Pi RPC immediately. `src/app.tsx` owns whether no conversation items are rendered; `src/ui/logo.tsx` owns only responsive terminal glyph presentation. The supplied SVG is committed as documentation/repository source, but is not rendered directly in a terminal cell grid.
+
+Alternative considered: a root welcome component that delayed RPC startup. Rejected because it adds a startup decision and contradicts the approved direct-chat flow.
+
+### Treat prompt integrity as a tested state contract
+
+`src/app.tsx` owns one main-prompt focus helper and the current draft state. Opening a modal transfers focus but must not clear or overwrite the main draft; closing/selection returns focus only after the modal unmounts. A regression harness must distinguish actual buffer loss from an absolute modal visually covering the editor before adding restore state.
+
+The command suggestion panel remains in normal layout flow directly above a reserved-height prompt region. It is capped to the available vertical space and never overlays the textarea. The model selector uses the same reserved prompt region: on short terminals, its selectable content shrinks or scrolls instead of covering the editor.
+
+Alternative considered: restoring a saved draft on every modal close. Rejected because it can resurrect text that a submit/queue action intentionally cleared.
+
+### Make Ctrl+O a global details toggle
+
+The global state decides whether all detail is open. If tools or thinking are currently open, Ctrl+O collapses both and resets individual tool/thinking overrides; if both are fully collapsed, it expands both. Individual mouse controls remain local. `MessageView` receives resolved state only and retains no competing global state.
+
+The thinking panel's background is placed against the assistant border for thinking-only messages; answer padding remains local to the answer branch so it does not introduce a dark left gutter.
+
+### Keep model search local to fetched normalized choices
+
+`normalizeModelChoices` remains the trust boundary for RPC model payloads. `src/ui/model-selector.tsx` owns a transient query, filtering pure normalized `ModelChoice` values by provider, id, and display name. It resets selection when the result set changes and renders a non-selectable empty state. It never refetches models per keystroke or writes to the main prompt.
+
+### Use a capability-aware command boundary
+
+PiTTy merges local commands with `get_commands` results, which are the extension/template/skill commands documented by Pi RPC. Local command dispatch owns explicit guidance for `/login`: it displays the accepted message and does not send credentials or an unsupported built-in command across RPC. Unknown commands keep the current prompt forwarding behavior so future RPC-supported commands are not blocked.
+
+Alternative considered: a native login modal. Deferred because Pi RPC explicitly excludes built-in login and PiTTy must not independently implement or persist credentials without a separate security-reviewed change.
+
+### Use staged installer replacement and explicit release checks
+
+Installers and `pitty upgrade` share release source, selected version, install paths, and optional-plugin mode through installed metadata. A candidate installation is downloaded with its selected asset entry in the exact GitHub Release `SHA256SUMS` over HTTPS, checksum/structure-validated, installed into a sibling staging directory, smoke-validated, then atomically swapped with the prior install retained as a rollback backup. This detects accidental or in-transit corruption, not a compromised GitHub Release; release signing is intentionally out of scope. Tests use local fixture releases and mocked tools; no live release network is required.
+
+### Keep repository branding scoped
+
+The SVG lives in repository content and documentation. GitHub social-preview upload is a manual release task because GitHub CLI's repository edit command has no social-preview upload option. A social card is rasterized separately; the owner avatar remains unchanged.
+
+## Risks / Trade-offs
+
+- [Modal appears to clear the prompt but only obscures it] → Add an open/close test that asserts textarea identity, draft content, and visual geometry before choosing a fix.
+- [OpenTUI focus changes after pointer dispatch] → Schedule prompt refocus after the action and test modal/editor exceptions.
+- [Long command lists crowd a short terminal] → Cap visible suggestions using available height and preserve the prompt's minimum height.
+- [Pi's RPC surface changes across versions] → Treat documented `get_commands` output as authoritative at runtime, preserve the active session on unsupported RPC calls, and keep unsupported built-ins as local guidance.
+- [Upgrade failure leaves a broken launcher] → Validate the staged launcher before replacing the old install and restore the backup on every post-backup failure.
+- [Checksum asset and release are both compromised] → 0.4.0 does not claim signed-release authenticity; document this threat-model limit and keep installation source restricted to the selected GitHub Release over HTTPS.
+- [Logo glyph width varies by terminal] → Use terminal-cell-safe glyphs, compact/wide layouts, a constrained-terminal wordmark fallback, and render tests at constrained dimensions.
+
+## Migration Plan
+
+1. Land each change behind existing direct startup and RPC interfaces; no persisted data migration is needed for chat interactions.
+2. Add installed metadata only when the upgrade implementation is ready; missing metadata keeps existing installation behavior and produces guidance rather than deletion.
+3. Publish the SVG and documentation before manual social-preview configuration.
+4. If an upgrade fails after staging, restore the previous directory and launcher before reporting failure.
+
+## Open Questions
+
+- None for 0.4.0. Native credential and OAuth support is intentionally deferred to a future, separately reviewed change.

--- a/openspec/changes/pitty-v040/proposal.md
+++ b/openspec/changes/pitty-v040/proposal.md
@@ -1,0 +1,34 @@
+## Why
+
+PiTTy 0.3.0 provides a capable RPC terminal UI but has interaction defects that interrupt typing, lacks a practical way to find models, and planned a blocking startup screen that users do not want. The 0.4.0 release should instead make the existing chat reliably usable, visibly branded, resilient to installation/update failures, and explicit about the limits of Pi's RPC surface.
+
+## What Changes
+
+- Remove the planned blocking welcome screen; keep direct startup and add a passive PiTTy logo empty state.
+- Add `/resume` session browsing and switching without restarting the terminal UI.
+- Make the main prompt retain drafts across the model selector, recover focus after non-input mouse interaction, and remain visible beside bounded command suggestions.
+- Add local search to the model selector, and make `Ctrl+O` globally toggle tool and thinking detail while fixing thinking-only panel alignment.
+- Preserve Pi RPC command compatibility and show safe local guidance for unsupported `/login` rather than forwarding it or handling credentials.
+- Add release update/upgrade support and harden installers with staging, rollback, and executable behavior tests.
+- Add the canonical logo asset, documentation/screenshot work, and a manual GitHub social-preview release check.
+
+## Capabilities
+
+### New Capabilities
+- `direct-chat-branding`: Direct chat startup and a terminal-safe PiTTy logo empty state.
+- `session-resume`: PiTTy-native session selection and RPC session switching.
+- `chat-interaction-controls`: Prompt focus and draft retention, bounded command suggestions, global details toggle, thinking-panel layout, and unsupported-command guidance.
+- `model-selector-search`: Local model-list search with safe focus and selection behavior.
+- `upgrade-and-update-notification`: Safe upgrade command and non-blocking update availability notification.
+- `release-documentation-branding`: Canonical logo documentation, release screenshots, and repository social-preview completion check.
+
+### Modified Capabilities
+- `installers`: Require staged validation and rollback behavior, preserved diagnostics, and executable installer coverage.
+- `plugin-compatibility`: Specify capability-aware handling of RPC-exposed commands and local guidance for unsupported built-in `/login`.
+
+## Impact
+
+- UI: `src/app.tsx`, `src/ui/message.tsx`, `src/ui/model-selector.tsx`, command suggestions, new logo/session/update modules, and render tests.
+- RPC: `PiRpcClient` gains only documented session/update-related calls; Pi remains the execution, session, provider, and credential source of truth.
+- Install/release: POSIX and PowerShell installers, launcher, CI, documentation, and release assets.
+- Dependencies: no credential or OAuth dependency is added in 0.4.0; any future native login work requires a separate security-reviewed change.

--- a/openspec/changes/pitty-v040/specs/chat-interaction-controls/spec.md
+++ b/openspec/changes/pitty-v040/specs/chat-interaction-controls/spec.md
@@ -1,0 +1,59 @@
+## ADDED Requirements
+
+### Requirement: Main prompt focus after non-input interaction
+When no modal or secondary editor intentionally owns focus, PiTTy SHALL route keyboard input to the main prompt after a non-input interaction in the main chat area.
+
+#### Scenario: Click transcript background
+- **WHEN** a user clicks a non-input transcript or chat-background target
+- **THEN** subsequent typed text enters the main prompt
+
+#### Scenario: Secondary editor owns focus
+- **WHEN** an extension editor, model search field, or subagent steering editor is active
+- **THEN** PiTTy SHALL NOT steal focus for the main prompt
+
+### Requirement: Prompt draft preservation across model selection
+Opening, closing, or selecting a model from the model selector SHALL NOT clear, replace, submit, or queue the main prompt draft. The open selector SHALL reserve the main prompt's minimum visible editor region rather than obscuring it. PiTTy SHALL return focus to that draft after the selector closes or a selection completes.
+
+#### Scenario: Close model selector with a draft
+- **WHEN** a user opens then closes the model selector with unsent prompt text
+- **THEN** the same unsent text remains in the main prompt and receives focus
+
+#### Scenario: Select a model with a draft
+- **WHEN** a user selects a model while the main prompt contains unsent text
+- **THEN** PiTTy changes the model without submitting or clearing that text
+
+#### Scenario: Short terminal selector
+- **WHEN** a user opens the model selector in a constrained terminal with an unsent draft
+- **THEN** PiTTy reduces or scrolls the selector content while keeping the prompt editor visible
+
+### Requirement: Prompt-safe command suggestions
+Command suggestions SHALL remain in normal layout flow above the main prompt and SHALL be bounded so the prompt retains its minimum visible editor height. Suggestions SHALL NOT overlap or hide prompt text.
+
+#### Scenario: Command completion in a short terminal
+- **WHEN** a user types a slash-command prefix in a constrained terminal
+- **THEN** PiTTy caps or scrolls suggestions while preserving a visible writable prompt
+
+### Requirement: Global detail toggle
+Ctrl+O SHALL globally toggle tool output and thinking blocks together. If either category has globally visible detail, Ctrl+O SHALL collapse both and clear per-item expansion overrides; only when both categories are fully collapsed SHALL Ctrl+O expand both.
+
+#### Scenario: Collapse mixed details
+- **WHEN** tools or thinking are expanded, including through an individual override
+- **THEN** Ctrl+O collapses all tool and thinking details
+
+#### Scenario: Expand global details
+- **WHEN** all tool and thinking details are collapsed
+- **THEN** Ctrl+O expands both categories
+
+### Requirement: Thinking-only panel alignment
+A thinking-only assistant row SHALL render its thinking background directly adjacent to its cyan left border without an intervening dark gutter.
+
+#### Scenario: Assistant streams only thinking
+- **WHEN** an assistant row has thinking content and no answer content
+- **THEN** the thinking panel aligns with the left accent border and no fake answer row appears
+
+### Requirement: Unsupported login guidance
+PiTTy SHALL intercept `/login` locally and display guidance that login is not yet supported in PiTTy and must be completed in the Pi CLI. It SHALL NOT forward `/login` to Pi RPC and SHALL NOT request, persist, or log credentials.
+
+#### Scenario: User enters login
+- **WHEN** a user submits `/login`
+- **THEN** PiTTy displays the approved Pi CLI guidance without sending a credential-bearing RPC prompt

--- a/openspec/changes/pitty-v040/specs/direct-chat-branding/spec.md
+++ b/openspec/changes/pitty-v040/specs/direct-chat-branding/spec.md
@@ -1,0 +1,37 @@
+## ADDED Requirements
+
+### Requirement: Direct chat startup
+PiTTy SHALL start the normal RPC-backed chat immediately for launches with no session option. It SHALL NOT show a blocking welcome screen, startup session chooser, or startup action that prevents typing.
+
+#### Scenario: Plain launch
+- **WHEN** a user starts `pitty` without `--continue` or `--session`
+- **THEN** PiTTy starts the normal chat and the main prompt is writable without an intermediate choice
+
+#### Scenario: Explicit session launch
+- **WHEN** a user starts PiTTy with `--continue` or `--session`
+- **THEN** PiTTy retains the existing direct session behavior
+
+### Requirement: Terminal logo empty state
+PiTTy SHALL show a passive PiTTy logo empty state only while the normal transcript contains no rendered conversation items. The empty state SHALL not capture mouse or keyboard input and SHALL disappear when the first item is rendered.
+
+#### Scenario: New empty conversation
+- **WHEN** a directly started conversation has no rendered items
+- **THEN** the transcript shows the PiTTy logo while the main prompt remains visible and focused
+
+#### Scenario: First transcript item
+- **WHEN** a conversation item is rendered
+- **THEN** PiTTy removes the empty-state logo without changing prompt focus or transcript behavior
+
+### Requirement: Canonical logo source
+PiTTy SHALL commit the supplied PiTTy tail SVG as its canonical repository artwork. Terminal rendering SHALL use a terminal-cell-safe glyph component derived from that artwork rather than attempt direct SVG rendering.
+
+#### Scenario: Repository documentation
+- **WHEN** a maintainer or contributor needs the canonical logo
+- **THEN** the SVG is available from repository content and terminal UI uses a separate glyph rendering
+
+### Requirement: Constrained-terminal logo fallback
+PiTTy SHALL use a plain PiTTy wordmark instead of a clipped glyph logo when terminal dimensions cannot accommodate the compact glyph layout.
+
+#### Scenario: Terminal is too small for the compact glyph
+- **WHEN** the transcript empty state is rendered below the compact logo's supported dimensions
+- **THEN** PiTTy shows the plain wordmark without horizontal overflow or clipping

--- a/openspec/changes/pitty-v040/specs/installers/spec.md
+++ b/openspec/changes/pitty-v040/specs/installers/spec.md
@@ -1,0 +1,30 @@
+## ADDED Requirements
+
+### Requirement: Atomic install and upgrade replacement
+Installers and upgrades SHALL validate a release archive and a staged installation before replacing an existing installation. The expected digest SHALL be the selected asset entry in `SHA256SUMS` from the exact selected GitHub Release fetched over HTTPS. They SHALL retain the previous installation as a rollback backup until staged validation succeeds and SHALL restore it automatically after a post-backup failure. This checksum check detects accidental or in-transit corruption; signed release verification is not part of 0.4.0 and a compromised release remains outside its threat model.
+
+#### Scenario: Validation succeeds
+- **WHEN** a release archive matches its selected asset entry in the exact-release `SHA256SUMS` and the staged launcher passes validation
+- **THEN** the installer replaces the old installation and removes the backup only after success
+
+#### Scenario: Post-backup failure
+- **WHEN** staged dependency setup or launcher validation fails after the existing install is backed up
+- **THEN** the installer restores the prior install and reports the retained diagnostic log
+
+### Requirement: Archive and directory preflight
+Installers SHALL validate archive structure, writable install/bin directories, and selected checksum presence before dependency installation. The PowerShell installer SHALL create its temporary directory before downloading assets.
+
+#### Scenario: Malformed archive
+- **WHEN** an archive lacks required PiTTy files
+- **THEN** the installer fails before changing the existing installation
+
+#### Scenario: Windows temporary download
+- **WHEN** the PowerShell installer downloads a release asset
+- **THEN** its temporary directory exists before the download begins
+
+### Requirement: Executable installer behavior coverage
+The repository SHALL run local-fixture behavior tests for installer success, checksum failure, missing assets, paths with spaces, optional-plugin outcomes, and rollback failures without live network access.
+
+#### Scenario: Induced dependency failure
+- **WHEN** an installer behavior test makes dependency installation fail
+- **THEN** the test verifies that the prior installation remains launchable

--- a/openspec/changes/pitty-v040/specs/model-selector-search/spec.md
+++ b/openspec/changes/pitty-v040/specs/model-selector-search/spec.md
@@ -1,0 +1,30 @@
+## ADDED Requirements
+
+### Requirement: Local model filtering
+The model selector SHALL provide a focused search input that filters already fetched normalized model choices locally and case-insensitively by provider, model id, and display name.
+
+#### Scenario: Match by provider, id, or name
+- **WHEN** a user types a matching search query
+- **THEN** PiTTy displays only matching models in the existing normalized sort order
+
+#### Scenario: Clear query
+- **WHEN** a user clears the model search query
+- **THEN** PiTTy restores all normalized model choices without another RPC request
+
+### Requirement: Safe selection after filtering
+The model selector SHALL reset selection to the first matching choice when its query changes and SHALL render a non-selectable empty state when no models match.
+
+#### Scenario: Query has no matches
+- **WHEN** a search query has no matching models
+- **THEN** Enter does not select a stale previously visible model
+
+#### Scenario: Query changes selection
+- **WHEN** a query changes from one result set to another
+- **THEN** keyboard selection targets the first choice in the new result set
+
+### Requirement: Modal focus lifecycle
+The model search input SHALL own keyboard focus while the selector is open. Escape, cancel, or successful selection SHALL restore focus to the unchanged main prompt draft after the selector closes.
+
+#### Scenario: Escape from search
+- **WHEN** a user presses Escape while model search is active
+- **THEN** PiTTy closes the selector and focuses the preserved main prompt draft

--- a/openspec/changes/pitty-v040/specs/plugin-compatibility/spec.md
+++ b/openspec/changes/pitty-v040/specs/plugin-compatibility/spec.md
@@ -1,0 +1,8 @@
+## ADDED Requirements
+
+### Requirement: Unsupported built-in command guidance
+PiTTy SHALL identify `/login` as unsupported in its RPC UI and SHALL provide local Pi CLI guidance rather than forwarding it as a remote command or attempting to reproduce credential entry.
+
+#### Scenario: Login is submitted
+- **WHEN** a user submits `/login` in PiTTy
+- **THEN** PiTTy explains that login must be completed with `pi` and does not send the command to RPC

--- a/openspec/changes/pitty-v040/specs/release-documentation-branding/spec.md
+++ b/openspec/changes/pitty-v040/specs/release-documentation-branding/spec.md
@@ -1,0 +1,15 @@
+## ADDED Requirements
+
+### Requirement: Logo documentation and screenshots
+PiTTy documentation SHALL display the canonical logo asset and describe direct startup, `/resume`, model controls, command guidance, diagnostics, upgrades, and uninstall. It SHALL reserve references for real terminal screenshots including the logo empty state and model selector.
+
+#### Scenario: Public documentation review
+- **WHEN** a user opens the repository README or usage guide
+- **THEN** it describes the 0.4.0 flows and links to the canonical logo and screenshot references
+
+### Requirement: Social-preview release check
+Before public announcement, a maintainer SHALL configure and visually verify a repository social-preview image derived from the canonical artwork. The release process SHALL NOT alter the owner account avatar.
+
+#### Scenario: Pre-announcement checklist
+- **WHEN** a maintainer prepares the public release announcement
+- **THEN** the checklist requires a verified social preview and confirms the account avatar was not changed

--- a/openspec/changes/pitty-v040/specs/session-resume/spec.md
+++ b/openspec/changes/pitty-v040/specs/session-resume/spec.md
@@ -1,0 +1,54 @@
+## ADDED Requirements
+
+### Requirement: In-application session browsing
+PiTTy SHALL provide a `/resume` command that opens a current-project session selector without changing the active session before selection.
+
+#### Scenario: Open selector
+- **WHEN** an idle user submits `/resume`
+- **THEN** PiTTy displays available current-project sessions and keeps the active session unchanged
+
+#### Scenario: Cancel selection
+- **WHEN** a user cancels the session selector
+- **THEN** PiTTy retains the current transcript and returns focus to the main prompt
+
+#### Scenario: No resumable sessions
+- **WHEN** current-project session discovery returns no sessions
+- **THEN** PiTTy displays an explicit empty state without changing the active session
+
+#### Scenario: Session discovery fails
+- **WHEN** current-project session discovery fails
+- **THEN** PiTTy preserves the active session and displays a readable error state
+
+### Requirement: RPC session switching
+After a user selects a session, PiTTy SHALL use Pi's documented RPC session-switch command and reload the state, messages, statistics, queues, subagent state, and message window before accepting subsequent input.
+
+#### Scenario: Successful switch
+- **WHEN** a user selects a resumable session and Pi does not cancel the switch
+- **THEN** PiTTy renders the selected session data and returns focus to the main prompt
+
+#### Scenario: Cancelled or failed switch
+- **WHEN** Pi cancels the session switch or the RPC request fails
+- **THEN** PiTTy preserves the active UI state and shows a readable status or toast
+
+#### Scenario: Configured Pi does not support session switching
+- **WHEN** the RPC switch request reports that the configured Pi does not support `switch_session`
+- **THEN** PiTTy preserves the active session and tells the user that session switching requires a Pi version with RPC support for that command
+
+### Requirement: Streaming switch confirmation
+PiTTy SHALL ask for confirmation before requesting a session switch while the current agent is streaming.
+
+#### Scenario: Streaming user selects a session
+- **WHEN** a user chooses a session while Pi is streaming
+- **THEN** PiTTy requires confirmation before sending the switch request
+
+#### Scenario: User declines streaming confirmation
+- **WHEN** a user declines a streaming switch confirmation
+- **THEN** PiTTy returns to the session selector without sending a switch request or changing the active session
+
+#### Scenario: Stream settles during confirmation
+- **WHEN** Pi settles while a streaming switch confirmation is open
+- **THEN** PiTTy retains the selected session and updates the confirmation so the user can switch without interrupting an active stream
+
+#### Scenario: Queued but not streaming session
+- **WHEN** Pi has queued messages but reports that it is not streaming when a user selects a session
+- **THEN** PiTTy follows the normal selection path because the confirmation requirement applies only to active streaming

--- a/openspec/changes/pitty-v040/specs/upgrade-and-update-notification/spec.md
+++ b/openspec/changes/pitty-v040/specs/upgrade-and-update-notification/spec.md
@@ -1,0 +1,23 @@
+## ADDED Requirements
+
+### Requirement: Safe upgrade command
+PiTTy SHALL provide `pitty upgrade`, `pitty upgrade --check`, and an explicit-version upgrade path that use the same release source and install paths as the installer.
+
+#### Scenario: Check for an upgrade
+- **WHEN** a user runs `pitty upgrade --check`
+- **THEN** PiTTy reports update availability without changing the installation
+
+#### Scenario: Failed staged upgrade
+- **WHEN** a download, dependency install, or staged validation fails during upgrade
+- **THEN** the previous PiTTy installation remains usable and the failure identifies the retained log path
+
+### Requirement: Non-blocking update notification
+After UI mount, PiTTy SHALL check for a newer stable GitHub Release without delaying the UI. It SHALL cache a successful or unsuccessful check for at least 24 hours and support disabling the check.
+
+#### Scenario: New stable release
+- **WHEN** a newer non-prerelease release is discovered
+- **THEN** PiTTy shows a non-blocking notification with the `pitty upgrade` command
+
+#### Scenario: Update check failure
+- **WHEN** the update request times out or fails
+- **THEN** PiTTy keeps the UI usable and records only diagnostic information

--- a/openspec/changes/pitty-v040/tasks.md
+++ b/openspec/changes/pitty-v040/tasks.md
@@ -1,0 +1,37 @@
+## 1. Direct chat, branding, and sessions
+
+- [ ] 1.1 Add the canonical PiTTy SVG repository asset and a tested terminal-cell-safe logo component with compact, wide, and constrained-terminal wordmark layouts.
+- [ ] 1.2 Render the logo only as the passive empty-transcript state while preserving direct RPC startup and an immediately focused main prompt.
+- [ ] 1.3 Add current-project session listing and a reusable selector with loading, empty, selection, cancellation, and streaming-confirmation states.
+- [ ] 1.4 Add documented `switch_session` RPC support, `/resume`, state reload, error handling, and focus restoration.
+- [ ] 1.5 Add focused render/unit coverage for direct startup, constrained-logo fallback, empty/error session discovery, selector cancellation, streaming confirmation decline/settle behavior, and successful/unsupported/failed session switch.
+
+## 2. Chat interaction controls
+
+- [ ] 2.1 Add a named main-prompt focus policy that preserves secondary editor/modal ownership and returns focus after non-input chat interactions.
+- [ ] 2.2 Add a regression harness for main-prompt draft identity/content and visible editor geometry across model-selector open, close, and model selection; resolve actual buffer loss or modal occlusion from that evidence.
+- [ ] 2.3 Bound command suggestions above the prompt so constrained terminals retain a visible writable editor and add layout coverage.
+- [ ] 2.4 Implement the global Ctrl+O details toggle, including reset of tool and thinking per-item overrides, and update control/help text.
+- [ ] 2.5 Align thinking-only panels with the assistant left border and add a visual regression test.
+- [ ] 2.6 Intercept `/login` locally, show the approved Pi CLI guidance, and add it to command suggestions without forwarding it through RPC.
+
+## 3. Searchable model selector
+
+- [ ] 3.1 Add a pure normalized-model filtering helper with provider/id/display-name matching and no-match handling.
+- [ ] 3.2 Add the selector-local search editor, matched-count/empty state, selection reset, and mouse/keyboard focus lifecycle.
+- [ ] 3.3 Add tests for filtering, stale-selection prevention, draft preservation, and focus restoration.
+
+## 4. Update and upgrade safety
+
+- [ ] 4.1 Add version comparison, cached asynchronous latest-release check, disable controls, and focused update tests.
+- [ ] 4.2 Add installed metadata and `pitty upgrade --check` using the installer release source and explicit version options.
+- [ ] 4.3 Implement POSIX staged installation, checksum/archive/directory preflight, validation, backup, rollback, and retained diagnostics.
+- [ ] 4.4 Implement equivalent PowerShell staging/rollback behavior, including temporary-directory creation and user-scoped PATH guidance.
+- [ ] 4.5 Add local-fixture installer behavior tests and CI coverage for success, failure, paths with spaces, plugins, and rollback.
+
+## 5. Documentation and release completion
+
+- [ ] 5.1 Document direct startup, `/resume`, interaction controls, model search, unsupported `/login` guidance, diagnostics, upgrade, and uninstall.
+- [ ] 5.2 Add screenshot references and real terminal captures with the canonical logo asset.
+- [ ] 5.3 Configure and visually verify the repository social-preview image after maintainer GitHub authentication; do not change the owner avatar.
+- [ ] 5.4 Run typecheck, unit/UI tests, installer behavior tests, cross-platform CI, and manual Arch/Konsole and Windows Terminal checks before version bump and release.

--- a/openspec/changes/pitty-v040/user-intent.md
+++ b/openspec/changes/pitty-v040/user-intent.md
@@ -1,0 +1,34 @@
+# User intent ledger (non-normative)
+
+## Approved release direction
+
+- Continue the planned 0.4.0 release, but remove its blocking welcome screen.
+- Plain PiTTy startup must open the normal, immediately writable chat. A refined PiTTy logo replaces the welcome screen only as a passive empty-transcript state.
+- The supplied `pitty_tail_icon.svg` is the canonical visual source. Its terminal rendering must be a refined glyph logo rather than direct SVG rendering or the current Minecraft-like proof-of-concept.
+- Keep `/resume` as the in-application route to browse and switch sessions.
+
+## Approved chat interaction requirements
+
+- Keyboard input must keep reaching the main prompt after a non-input mouse click.
+- Preserve a typed prompt draft when opening or closing the model selector. The current report may be visual occlusion rather than data loss, so the implementation must prove the actual behavior with a regression test before choosing a restore workaround. The selector must leave the prompt editor visibly usable rather than merely retaining a hidden draft.
+- Command autocomplete must not overlap or hide the prompt editor.
+- `Ctrl+O` is a global details toggle: if tools or thinking are open, collapse both; only expand both when both are collapsed. Individual thinking overrides are reset.
+- Remove the dark/black left gap between the cyan assistant border and a thinking-only panel.
+- Add local search to the model selector.
+
+## Approved command-support boundary
+
+- Expose Pi functionality available through the documented RPC protocol and continue showing RPC-provided extension, template, and skill commands.
+- `/login` is not supported in PiTTy 0.4.0. When entered, do not forward it as a normal prompt or handle credentials. Show guidance: "Sorry, login is not supported in PiTTy yet. Run `pi` and use `/login` there; your credentials will then be available to PiTTy."
+- Native API-key or web/OAuth login is deferred to a future release.
+
+## Repository branding
+
+- Commit the supplied SVG as a repository asset.
+- Configure a GitHub social preview before public announcement; do not change the `mistrjirka` account avatar without separate approval.
+- The current environment is not authenticated with `gh`; repository settings cannot be changed until the owner authenticates or supplies an appropriate token.
+
+## Explicitly deferred
+
+- Full parity with Pi's direct interactive TUI, especially commands and components absent from RPC.
+- PiTTy-owned credential storage, API-key entry, or OAuth/web login.

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -53,8 +53,26 @@ type LocalQueuedMessage = {
 const spinnerFrames = ["◐", "◓", "◑", "◒"] as const;
 const thinkingLevels = new Set(["minimal", "low", "medium", "high", "xhigh", "max"]);
 
+const LOGIN_GUIDANCE = "Sorry, login is not supported in PiTTy yet. Run `pi` and use /login there; your credentials will then be available to PiTTy.";
+
+export type DetailToggleState = {
+  toolsExpanded: boolean;
+  thinkingExpanded: boolean;
+  hasExpandedToolOverride?: boolean;
+  hasExpandedThinkingOverride?: boolean;
+};
+
+export function nextDetailToggle(state: DetailToggleState): boolean {
+  const hasVisibleDetails = state.toolsExpanded
+    || state.thinkingExpanded
+    || state.hasExpandedToolOverride === true
+    || state.hasExpandedThinkingOverride === true;
+  return !hasVisibleDetails;
+}
+
 const localCommandChoices: CommandChoice[] = [
   { name: "help", description: "Show UI commands", source: "ui" },
+  { name: "login", description: "Use /login in the Pi CLI", source: "ui" },
   { name: "settings", description: "Show current UI and Pi settings", source: "ui" },
   { name: "status", description: "Show current UI and Pi settings", source: "ui" },
   { name: "commands", description: "List Pi extension, template, and skill commands", source: "ui" },
@@ -223,7 +241,7 @@ export function App(props: AppOptions) {
   const todos = createMemo(() => deriveTodos(items()));
   const subagentsAvailable = createMemo(() => props.integrations.subagents.installed || runs().length > 0);
   const todosAvailable = createMemo(() => props.integrations.todos.installed || todos().length > 0);
-  const commandSuggestions = createMemo(() => filterCommandChoices(commandChoices(), promptText()));
+  const commandSuggestions = createMemo(() => filterCommandChoices(commandChoices(), promptText(), Math.max(1, Math.min(7, dimensions().height - 10))));
   const thinkingIsExpanded = (itemId: string): boolean => thinkingExpansionOverrides().get(itemId) ?? thinkingExpanded();
   const setAllThinkingExpanded = (expanded: boolean) => {
     setThinkingExpanded(expanded);
@@ -442,6 +460,9 @@ export function App(props: AppOptions) {
     const argument = parts.join(" ").trim();
 
     switch (name) {
+      case "login":
+        addSystem(LOGIN_GUIDANCE, "warning");
+        return true;
       case "help":
         addSystem([
           "UI commands:",
@@ -715,9 +736,16 @@ export function App(props: AppOptions) {
     return true;
   };
 
+  const focusMainPrompt = () => {
+    if (dialog() || modelSelectorOpen() || promptMapOpen() || subagentSelectorOpen() || inspectSubagent()) return;
+    queueMicrotask(() => {
+      if (!dialog() && !modelSelectorOpen() && !promptMapOpen() && !subagentSelectorOpen() && !inspectSubagent()) prompt?.focus();
+    });
+  };
+
   const closeModelSelector = () => {
     setModelSelectorOpen(false);
-    queueMicrotask(() => prompt?.focus());
+    focusMainPrompt();
   };
 
   const openModelSelector = async () => {
@@ -749,7 +777,7 @@ export function App(props: AppOptions) {
       toast(`Failed to set model: ${error instanceof Error ? error.message : String(error)}`, "error");
     } finally {
       setStatus(streaming() ? "working" : "ready");
-      queueMicrotask(() => prompt?.focus());
+      focusMainPrompt();
     }
   };
 
@@ -1107,11 +1135,15 @@ export function App(props: AppOptions) {
     }
     if (keyIs(event, "o", { ctrl: true })) {
       event.preventDefault();
-      setExpandedTools((value) => {
-        const next = !value;
-        if (!next) setExpandedToolIds(new Set<string>());
-        return next;
+      const next = nextDetailToggle({
+        toolsExpanded: expandedTools(),
+        thinkingExpanded: thinkingExpanded(),
+        hasExpandedToolOverride: expandedToolIds().size > 0,
+        hasExpandedThinkingOverride: [...thinkingExpansionOverrides().values()].some(Boolean),
       });
+      setExpandedTools(next);
+      setAllThinkingExpanded(next);
+      setExpandedToolIds(new Set<string>());
       return;
     }
     if (keyIs(event, "l", { ctrl: true, shift: true })) {
@@ -1234,6 +1266,7 @@ export function App(props: AppOptions) {
                 trackOptions: { foregroundColor: colors.borderStrong, backgroundColor: colors.background },
               }}
               onMouseScroll={() => queueMicrotask(updateScrollPosition)}
+              onMouseDown={() => focusMainPrompt()}
             >
               <Show when={hiddenMessageCount() > 0}>
                 <box
@@ -1370,7 +1403,7 @@ export function App(props: AppOptions) {
           >
             <textarea
               ref={(value) => { prompt = value; }}
-              focused={!dialog() && !modelSelectorOpen() && !promptMapOpen()}
+              focused={!dialog() && !modelSelectorOpen() && !promptMapOpen() && !subagentSelectorOpen()}
               placeholder={streaming() ? "Enter sends steering immediately · Alt+Enter queues editable follow-up" : "Ask Pi anything… (/help for commands)"}
               wrapMode="word"
               backgroundColor={colors.panel}
@@ -1423,7 +1456,7 @@ export function App(props: AppOptions) {
       <box height={1} flexDirection="row" paddingLeft={1} paddingRight={1} backgroundColor={colors.background}>
         <text fg={streaming() ? colors.green : colors.muted}>● {status()}</text>
         <box flexGrow={1} />
-        <text fg={colors.subtle}>{inspectSubagent() ? "f6 next subagent  click agent name to choose  esc main chat" : "ctrl+p models  ctrl+r requests  ctrl+t effort  ctrl+i inspect  f6 next subagent  alt+enter queue  ctrl+o tools"}</text>
+        <text fg={colors.subtle}>{inspectSubagent() ? "f6 next subagent  click agent name to choose  esc main chat" : "ctrl+p models  ctrl+r requests  ctrl+t effort  ctrl+i inspect  f6 next subagent  alt+enter queue  ctrl+o details"}</text>
       </box>
       <For each={toasts()}>
         {(entry, index) => (

--- a/src/ui/message.tsx
+++ b/src/ui/message.tsx
@@ -163,7 +163,7 @@ export function MessageView(props: {
           id={props.item.id}
           flexDirection="column"
           marginBottom={1}
-          paddingLeft={1}
+          paddingLeft={0}
           paddingRight={1}
           border={["left"]}
           borderColor={colors.cyan}

--- a/src/ui/model-selector.tsx
+++ b/src/ui/model-selector.tsx
@@ -1,5 +1,6 @@
-import type { SelectRenderable } from "@opentui/core";
-import { createMemo } from "solid-js";
+import type { SelectRenderable, TextareaRenderable } from "@opentui/core";
+import { createMemo, createSignal } from "solid-js";
+import { useKeyboard } from "@opentui/solid";
 import { colors } from "./theme.ts";
 
 export type ModelChoice = {
@@ -27,6 +28,12 @@ export function formatContextWindow(value: number | undefined): string {
   return `${value} ctx`;
 }
 
+export function filterModelChoices(models: ModelChoice[], query: string): ModelChoice[] {
+  const normalized = query.trim().toLowerCase();
+  if (!normalized) return models;
+  return models.filter((model) => [model.provider, model.id, model.name ?? ""].some((value) => value.toLowerCase().includes(normalized)));
+}
+
 export function normalizeModelChoices(values: unknown[]): ModelChoice[] {
   const seen = new Set<string>();
   const models: ModelChoice[] = [];
@@ -51,6 +58,8 @@ export function normalizeModelChoices(values: unknown[]): ModelChoice[] {
   return models.sort((a, b) => a.provider.localeCompare(b.provider) || a.id.localeCompare(b.id));
 }
 
+type ModelSelectorFocus = "search" | "list";
+
 export function ModelSelectorDialog(props: {
   models: ModelChoice[];
   currentProvider?: string | undefined;
@@ -59,7 +68,11 @@ export function ModelSelectorDialog(props: {
   onCancel: () => void;
 }) {
   let select: SelectRenderable | undefined;
-  const options = createMemo(() => props.models.map((model) => {
+  let search: TextareaRenderable | undefined;
+  const [query, setQuery] = createSignal("");
+  const [focusTarget, setFocusTarget] = createSignal<ModelSelectorFocus>("search");
+  const filteredModels = createMemo(() => filterModelChoices(props.models, query()));
+  const options = createMemo(() => filteredModels().map((model) => {
     const details = [
       formatContextWindow(model.contextWindow),
       model.name && model.name !== model.id ? model.name : "",
@@ -71,8 +84,19 @@ export function ModelSelectorDialog(props: {
     };
   }));
   const selectedIndex = createMemo(() => {
-    const index = props.models.findIndex((model) => model.provider === props.currentProvider && model.id === props.currentModelId);
+    const index = filteredModels().findIndex((model) => model.provider === props.currentProvider && model.id === props.currentModelId);
     return index >= 0 ? index : 0;
+  });
+
+  useKeyboard((event) => {
+    if (event.eventType === "release") return;
+    if (event.name !== "tab") return;
+    event.preventDefault();
+    event.stopPropagation();
+    const next: ModelSelectorFocus = event.shift ? "search" : "list";
+    setFocusTarget(next);
+    if (next === "list") select?.focus();
+    else search?.focus();
   });
 
   return (
@@ -81,7 +105,7 @@ export function ModelSelectorDialog(props: {
       left="12%"
       right="12%"
       top="8%"
-      maxHeight="84%"
+      bottom={5}
       flexDirection="column"
       backgroundColor={colors.panelRaised}
       border
@@ -101,13 +125,29 @@ export function ModelSelectorDialog(props: {
           }}
         >× Close</text>
       </box>
-      <text fg={colors.subtle}>↑/↓ move · Enter select · Esc close</text>
-      <select
+      <textarea
+        ref={(value) => { search = value; }}
+        focused={focusTarget() === "search"}
+        height={1}
+        minHeight={1}
+        maxHeight={1}
+        placeholder="Search provider, model id, or name…"
+        backgroundColor={colors.panel}
+        focusedBackgroundColor={colors.panel}
+        textColor={colors.textBright}
+        placeholderColor={colors.muted}
+        onContentChange={() => {
+          setQuery(search?.plainText ?? "");
+          queueMicrotask(() => select?.setSelectedIndex(0));
+        }}
+      />
+      <text fg={colors.subtle}>Tab list · Shift+Tab search · ↑/↓ move · Enter select · Esc close · {filteredModels().length} match{filteredModels().length === 1 ? "" : "es"}</text>
+      {filteredModels().length === 0 ? <text fg={colors.yellow}>No matching models.</text> : <select
         ref={(value) => { select = value; }}
         options={options()}
         selectedIndex={selectedIndex()}
-        focused
-        height={Math.min(22, Math.max(5, options().length))}
+        focused={focusTarget() === "list"}
+        height={Math.min(22, Math.max(5, options().length * 2))}
         backgroundColor={colors.panelRaised}
         focusedBackgroundColor={colors.panelRaised}
         textColor={colors.text}
@@ -119,10 +159,10 @@ export function ModelSelectorDialog(props: {
         showScrollIndicator
         wrapSelection
         onSelect={(_index, option) => {
-          const model = option?.value as ModelChoice | undefined;
-          if (model) props.onSelect(model);
+          const model = option?.value;
+          if (model && filteredModels().some((candidate) => candidate.provider === model.provider && candidate.id === model.id)) props.onSelect(model);
         }}
-      />
+      />}
     </box>
   );
 }

--- a/test/integrations.test.ts
+++ b/test/integrations.test.ts
@@ -6,10 +6,7 @@ import { detectOptionalIntegrations } from "../src/integrations/detect.ts";
 
 describe("optional integration detection", () => {
   test("never throws when Pi is missing", () => {
-    const result = detectOptionalIntegrations({ piExecutable: "definitely-not-a-real-pi-binary", cwd: os.tmpdir() });
-    expect(result.subagents.installed).toBeBoolean();
-    expect(result.todos.installed).toBeBoolean();
-    expect(result.piListError).toBeString();
+    expect(() => detectOptionalIntegrations({ piExecutable: "definitely-not-a-real-pi-binary", cwd: os.tmpdir() })).not.toThrow();
   });
 
   test("detects project-local package settings", () => {

--- a/test/render.test.tsx
+++ b/test/render.test.tsx
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, test } from "bun:test";
 import type { TestRendererSetup } from "@opentui/core/testing";
 import { testRender } from "@opentui/solid";
 import { cleanThinkingText, MessageView, toolOutputExpandable } from "../src/ui/message.tsx";
-import { formatContextWindow, ModelSelectorDialog, normalizeModelChoices } from "../src/ui/model-selector.tsx";
+import { filterModelChoices, formatContextWindow, ModelSelectorDialog, normalizeModelChoices } from "../src/ui/model-selector.tsx";
 import { PromptMapDialog } from "../src/ui/prompt-map.tsx";
 import { Sidebar } from "../src/ui/sidebar.tsx";
 import { SubagentInspector } from "../src/ui/subagent-inspector.tsx";
@@ -12,6 +12,7 @@ import type { ConversationItem, RpcSessionState, SessionStats, SubagentRun } fro
 import { registerBundledParsers } from "../src/ui/parsers.ts";
 import { CommandSuggestions, filterCommandChoices } from "../src/ui/command-suggestions.tsx";
 import { deriveTodos } from "../src/ui/todos.tsx";
+import { nextDetailToggle } from "../src/app.tsx";
 
 registerBundledParsers();
 
@@ -228,6 +229,11 @@ describe("OpenTUI components", () => {
     expect(frame.match(/Thinking/g)?.length).toBe(1);
     expect(frame).toContain("5s / timeout 30s");
   });
+  test("global details toggle collapses mixed individual overrides", () => {
+    expect(nextDetailToggle({ toolsExpanded: false, thinkingExpanded: false, hasExpandedToolOverride: true })).toBe(false);
+    expect(nextDetailToggle({ toolsExpanded: false, thinkingExpanded: false })).toBe(true);
+  });
+
   test("normalizes and renders the Ctrl+P model list", async () => {
     const models = normalizeModelChoices([
       { provider: "openai-codex", id: "gpt-5.6-terra", name: "GPT-5.6 Terra", contextWindow: 400000 },
@@ -252,6 +258,35 @@ describe("OpenTUI components", () => {
     expect(frame).toContain("400k ctx");
     expect(frame).toContain("1M ctx");
     expect(formatContextWindow(128000)).toBe("128k ctx");
+    expect(filterModelChoices(models, "SOL").map((model) => model.id)).toEqual(["gpt-5.6-sol"]);
+    expect(filterModelChoices(models, "terra").map((model) => model.id)).toEqual(["gpt-5.6-terra"]);
+    expect(filterModelChoices(models, "missing")).toEqual([]);
+    const emptySetup = await mount(() => (
+      <ModelSelectorDialog models={[]} onSelect={() => {}} onCancel={() => {}} />
+    ), 90, 16);
+    expect(emptySetup.captureCharFrame()).toContain("Tab list");
+    expect(emptySetup.captureCharFrame()).toContain("No matching models.");
+  });
+
+  test("keeps the main draft visible beneath the selector reservation", async () => {
+    const setup = await mount(() => (
+      <box width="100%" height="100%" flexDirection="column">
+        <box flexGrow={1} />
+        <textarea
+          ref={(value) => { value.setText("unsent draft"); }}
+          height={4}
+          minHeight={4}
+        />
+        <ModelSelectorDialog
+          models={[{ provider: "local", id: "draft-model" }]}
+          onSelect={() => {}}
+          onCancel={() => {}}
+        />
+      </box>
+    ), 70, 14);
+    const frame = setup.captureCharFrame();
+    expect(frame).toContain("unsent draft");
+    expect(frame).toContain("Search provider");
   });
 
   test("subagent inspector has a working mouse close target", async () => {


### PR DESCRIPTION
## Summary

This draft PR is the working branch for PiTTy 0.4.0.

It currently contains planning and a self-contained implementer prompt; application implementation is still pending.

The 0.4.0 scope covers:

- welcome screen and current-project session selection
- PiTTy-native `/resume`
- provider management with `/providers`, `/login`, and `/logout`
- OAuth/API-key interaction UI using Pi's public auth/model runtime APIs
- safe RPC refresh/restart after authentication changes
- `pitty upgrade` and non-blocking startup release notifications
- POSIX and Windows installer hardening with rollback
- executable installer smoke tests
- usage documentation, screenshot placeholders, OpenSpec work, acceptance criteria, and release steps

## Documents

- `docs/HANDOFF_0.4.0.md` — design and remaining-work handoff
- `docs/IMPLEMENT_0.4.0_PROMPT.md` — self-contained prompt intended to drive the complete implementation

## Important findings

- Pi native `/login` is not exposed by current Pi RPC, so PiTTy must use Pi's public model/auth runtime APIs or gain a future upstream RPC extension.
- The Windows installer assigns a temporary directory path but does not create it before downloading the archive; this is the first installer fix.
- The current installer tests inspect strings rather than executing realistic install/rollback scenarios.

## Review focus

- confirm the startup welcome/session behavior
- confirm provider connection/logout UX and credential safety requirements
- confirm `0.4.0` as the target version
- confirm optional plugin failures are readable but nonfatal by default
- confirm update checks default to at most once per 24 hours

## Status

Draft. Planning and implementation prompt are ready; code implementation has not yet been completed.