### PR TITLE
fix: PowerShell installer — byte[] parsing and smoke CWD

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -64,7 +64,8 @@ try {
   $MetadataJson = $Metadata | ConvertTo-Json -Compress
   [IO.File]::WriteAllText((Join-Path $NewDir "pitty-install.json"), "$MetadataJson`n", (New-Object Text.UTF8Encoding($false)))
   $SmokeLog = Join-Path $LogRoot "smoke.log"
-  & node (Join-Path $NewDir "bin\pitty.mjs") --help *> $SmokeLog
+  Push-Location $NewDir
+  try { & node (Join-Path $NewDir "bin\pitty.mjs") --help *> $SmokeLog } finally { Pop-Location }
   if ($LASTEXITCODE -ne 0) { Fail "staged smoke validation failed. See $SmokeLog" }
 
   if ($DeferApply) {
@@ -78,7 +79,8 @@ try {
     New-Item -ItemType Directory -Force -Path (Split-Path $InstallDir) | Out-Null
     if (Test-Path $InstallDir) { Move-Item $InstallDir $Backup; $MovedBackup = $true }
     Move-Item $NewDir $InstallDir
-    & node (Join-Path $InstallDir "bin\pitty.mjs") --help *> $SmokeLog
+    Push-Location $InstallDir
+    try { & node (Join-Path $InstallDir "bin\pitty.mjs") --help *> $SmokeLog } finally { Pop-Location }
     if ($LASTEXITCODE -ne 0) { Fail "installation smoke validation failed. See $SmokeLog" }
     if ($MovedBackup) { Remove-Item -Recurse -Force $Backup }
   } catch {

--- a/install.ps1
+++ b/install.ps1
@@ -37,7 +37,8 @@ try {
   Write-Host "Downloading PiTTy $Ver..."
   try { Invoke-WebRequest -Uri $Url -OutFile $Archive -UseBasicParsing } catch { Fail "Download failed: $Url`n$($_.Exception.Message)" }
   try { $Checksums = Invoke-WebRequest -Uri "https://github.com/$Repo/releases/download/$Tag/SHA256SUMS" -UseBasicParsing } catch { Fail "Release checksum could not be downloaded; refusing to install without verification. $($_.Exception.Message)" }
-  $ExpectedLine = ($Checksums.Content -split "`n" | Where-Object { $_ -match [regex]::Escape($Asset) } | Select-Object -First 1)
+  $ChecksumContent = if ($Checksums.Content -is [byte[]]) { [System.Text.Encoding]::UTF8.GetString($Checksums.Content) } else { $Checksums.Content }
+  $ExpectedLine = ($ChecksumContent -split "`n" | Where-Object { $_ -match [regex]::Escape($Asset) } | Select-Object -First 1)
   if (-not $ExpectedLine) { Fail "SHA256SUMS did not contain $Asset" }
   $Expected = ($ExpectedLine -split "\s+")[0].ToLowerInvariant()
   $Hasher = [System.Security.Cryptography.SHA256]::Create()


### PR DESCRIPTION
Two fixes for the PowerShell installer:

1. SHA256SUMS is served as application/octet-stream, so Invoke-WebRequest returns .Content as byte[] on both PowerShell 5.1 and 7+. Splitting a byte array per `n` yields individual bytes instead of lines, so the asset name is never matched. Fixed by converting byte[] to a UTF-8 string before parsing.

2. pitty.mjs spawns Bun with CWD inherited from the installer. If the user runs install.ps1 from a directory without bunfig.toml, Bun can't resolve the preload module. Fixed by wrapping both smoke validations in Push-Location / Pop-Location.

Tested on PowerShell 5.1 and 7.6.3.