### PR TITLE
fix: add bin dir to PATH on Windows, resolve pi spawn via cli.js

### DIFF
--- a/bin/pitty.mjs
+++ b/bin/pitty.mjs
@@ -10,6 +10,19 @@ function findBundledBun(directory) {
   const candidates = [path.join(directory, "node_modules", ".bin", bunName), path.join(directory, "node_modules", "bun", "bin", "bun.exe")];
   return candidates.find((candidate) => fs.existsSync(candidate));
 }
+function findPiEntryPoint() {
+  // On Windows, spawning "pi" directly does not work reliably because
+  // the extension-less shell script shadows pi.cmd in PATH resolution.
+  // Resolve the underlying JS entry point so the RPC client can spawn it
+  // via `node <script>`.
+  if (process.platform !== "win32") return null;
+  const npmDir = process.env.APPDATA
+    ? path.join(process.env.APPDATA, "npm")
+    : null;
+  if (!npmDir) return null;
+  const cliPath = path.join(npmDir, "node_modules", "@earendil-works", "pi-coding-agent", "dist", "cli.js");
+  return fs.existsSync(cliPath) ? cliPath : null;
+}
 function validateInstall(directory) {
   const launcher = path.join(directory, "bin", "pitty.mjs");
   const runtime = path.join(directory, "node_modules", ".bin", process.platform === "win32" ? "bun.exe" : "bun");
@@ -56,7 +69,10 @@ if (isUpgrade) {
     console.error("Re-run the installer, or run: npm ci --ignore-scripts && node node_modules/bun/install.js");
     process.exit(1);
   }
-  const child = spawn(bun, ["run", path.join(root, "src", "index.tsx"), ...process.argv.slice(2)], { cwd: process.cwd(), stdio: "inherit", env: process.env });
+  const env = { ...process.env };
+  const piEntry = findPiEntryPoint();
+  if (piEntry) env.PI_BIN = piEntry;
+  const child = spawn(bun, ["run", path.join(root, "src", "index.tsx"), ...process.argv.slice(2)], { cwd: root, stdio: "inherit", env });
   child.on("error", (error) => { console.error(`PiTTy failed to start: ${error.message}`); process.exit(1); });
   child.on("exit", (code, signal) => { if (signal) process.kill(process.pid, signal); else process.exit(code ?? 1); });
 }

--- a/install.ps1
+++ b/install.ps1
@@ -91,6 +91,14 @@ try {
   "@echo off`r`nnode `"$InstallDir\bin\pitty.mjs`" %*`r`n" | Set-Content -Encoding ASCII (Join-Path $BinDir "pitty.cmd")
   "@echo off`r`nnode `"$InstallDir\bin\pitty-resume.mjs`" %*`r`n" | Set-Content -Encoding ASCII (Join-Path $BinDir "pitty-resume.cmd")
 
+  $UserPath = [Environment]::GetEnvironmentVariable("PATH", "User") ?? ""
+  if ($UserPath -notlike "*$BinDir*") {
+    Write-Host "Adding $BinDir to user PATH..."
+    [Environment]::SetEnvironmentVariable("PATH", "$UserPath;$BinDir", "User")
+    $env:PATH = "$env:PATH;$BinDir"
+    Write-Host "Added to PATH. Restart your terminal for the change to take full effect."
+  }
+
   $PiList = if ($PluginMode -eq "ask" -or $PluginMode -eq "yes") { (& pi list 2>$null | Out-String) } else { "" }
   $Missing = @(); if (-not $PiList.Contains("pi-subagents")) { $Missing += "pi-subagents" }; if (-not $PiList.Contains("@juicesharp/rpiv-todo")) { $Missing += "@juicesharp/rpiv-todo" }
   if ($PluginMode -eq "ask" -and $Missing.Count -eq 0) { Write-Host "Recommended Pi packages are already installed; skipping plugin prompt."; $PluginMode = "no" }


### PR DESCRIPTION
- install.ps1: add BinDir to user PATH after creating .cmd launchers
- pitty.mjs: set cwd=root so Bun finds bunfig.toml (fixes missing SolidJS preload)
- pitty.mjs: find Pi CLI js entry point and pass via PI_BIN env var (avoids Windows PATH resolution picking the unspawnable bash script over pi.cmd)