### PR TITLE
fix: show startup update notices after upgrades

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.4.3
+
+- Fixed startup update notifications after upgrading PiTTy by scoping successful update-check caches to the local version.
+
 ## 0.4.2
 
 - Thanks to @herm1t0 for the Windows support intent in PRs #3 and #4; added safer installation PATH management and launcher/runtime fixes.

--- a/openspec/changes/pitty-v040/specs/upgrade-and-update-notification/spec.md
+++ b/openspec/changes/pitty-v040/specs/upgrade-and-update-notification/spec.md
@@ -12,7 +12,7 @@ PiTTy SHALL provide `pitty upgrade`, `pitty upgrade --check`, and an explicit-ve
 - **THEN** the previous PiTTy installation remains usable and the failure identifies the retained log path
 
 ### Requirement: Non-blocking update notification
-After UI mount, PiTTy SHALL check for a newer stable GitHub Release without delaying the UI. It SHALL cache a successful or unsuccessful check for at least 24 hours and support disabling the check.
+After UI mount, PiTTy SHALL check for a newer stable GitHub Release without delaying the UI. It SHALL cache a successful or unsuccessful check for at least 24 hours and support disabling the check. Successful caches are scoped to the local PiTTy version that was checked; a cached newer release may notify without another network request.
 
 #### Scenario: New stable release
 - **WHEN** a newer non-prerelease release is discovered

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pitty-pi-ui",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pitty-pi-ui",
-      "version": "0.4.2",
+      "version": "0.4.3",
       "dependencies": {
         "@earendil-works/pi-coding-agent": "0.80.6",
         "@opentui/core": "0.4.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pitty-pi-ui",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "private": false,
   "type": "module",
   "description": "PiTTy: a fast, extensible OpenTUI frontend for the Pi coding agent",

--- a/src/update/check.ts
+++ b/src/update/check.ts
@@ -21,11 +21,19 @@ export type UpdateCheckConfig = {
   onNewerRelease: (version: string) => void;
 };
 
-type UpdateCache = {
+type UpdateCacheSuccess = {
   checkedAt: number;
-  outcome: "success" | "failure";
-  version?: string;
+  outcome: "success";
+  version: string;
+  checkedForVersion?: string;
 };
+
+type UpdateCacheFailure = {
+  checkedAt: number;
+  outcome: "failure";
+};
+
+type UpdateCache = UpdateCacheSuccess | UpdateCacheFailure;
 
 type ReleasePayload = {
   tag_name: string;
@@ -67,13 +75,24 @@ export function isUpdateCheckDisabled(environment: UpdateEnvironment): boolean {
   return environment.PITTY_NO_UPDATE_CHECK === "1";
 }
 
+function isStableVersion(value: unknown): value is string {
+  if (typeof value !== "string") return false;
+  try {
+    compareStableVersions(value, value);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 function isUpdateCache(value: unknown): value is UpdateCache {
   if (!value || typeof value !== "object") return false;
   const record = value as Record<string, unknown>;
-  return typeof record.checkedAt === "number"
-    && Number.isFinite(record.checkedAt)
-    && (record.outcome === "success" || record.outcome === "failure")
-    && (record.version === undefined || typeof record.version === "string");
+  if (typeof record.checkedAt !== "number" || !Number.isFinite(record.checkedAt)) return false;
+  if (record.outcome === "failure") return true;
+  if (record.outcome !== "success") return false;
+  return isStableVersion(record.version)
+    && (record.checkedForVersion === undefined || isStableVersion(record.checkedForVersion));
 }
 
 function isReleasePayload(value: unknown): value is ReleasePayload {
@@ -115,7 +134,16 @@ export async function checkForUpdates(config: UpdateCheckConfig): Promise<void> 
   if (isUpdateCheckDisabled(config.environment)) return;
   const now = config.now();
   const cached = await readCache(config.cachePath);
-  if (cached && now >= cached.checkedAt && now - cached.checkedAt < CACHE_MAX_AGE_MS) return;
+  const isFresh = cached !== undefined && now >= cached.checkedAt && now - cached.checkedAt < CACHE_MAX_AGE_MS;
+  if (isFresh && cached.outcome === "failure") return;
+  if (isFresh && cached.outcome === "success") {
+    const cachedIsNewer = compareStableVersions(config.localVersion, cached.version) < 0;
+    if (cachedIsNewer) {
+      config.onNewerRelease(cached.version);
+      return;
+    }
+    if (cached.checkedForVersion !== undefined && compareStableVersions(cached.checkedForVersion, config.localVersion) === 0) return;
+  }
 
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), config.timeoutMs ?? DEFAULT_TIMEOUT_MS);
@@ -131,7 +159,7 @@ export async function checkForUpdates(config: UpdateCheckConfig): Promise<void> 
       throw new Error("GitHub returned an invalid stable release payload");
     }
     compareStableVersions(config.localVersion, payload.tag_name);
-    await writeCache(config.cachePath, { checkedAt: now, outcome: "success", version: payload.tag_name });
+    await writeCache(config.cachePath, { checkedAt: now, outcome: "success", version: payload.tag_name, checkedForVersion: config.localVersion });
     config.logger.info("update_check.release", { localVersion: config.localVersion, remoteVersion: payload.tag_name });
     if (compareStableVersions(config.localVersion, payload.tag_name) < 0) config.onNewerRelease(payload.tag_name);
   } catch (error) {

--- a/test/update.test.ts
+++ b/test/update.test.ts
@@ -49,14 +49,45 @@ describe("update checks", () => {
     expect(await fs.stat(cachePath).catch(() => undefined)).toBeUndefined();
     expect(isUpdateCheckDisabled({ PITTY_NO_UPDATE_CHECK: "1" })).toBe(true);
   });
-  test("uses fresh success and failure caches without requesting", async () => {
+  test("revalidates a fresh legacy success cache and persists its local version", async () => {
     await fs.writeFile(cachePath, JSON.stringify({ checkedAt: 1_000, outcome: "success", version: "0.3.3" }));
+    let calls = 0;
+    let announced = "";
+    const localConfig = config({ localVersion: "0.3.4", fetch: async () => { calls++; return new Response(JSON.stringify({ tag_name: "v0.4.2" }), { status: 200 }); }, onNewerRelease: (version) => { announced = version; } });
+    await checkForUpdates(localConfig);
+    expect(calls).toBe(1);
+    expect(announced).toBe("v0.4.2");
+    expect(JSON.parse(await fs.readFile(cachePath, "utf8")).checkedForVersion).toBe("0.3.4");
+    announced = "";
+    await checkForUpdates(localConfig);
+    expect(calls).toBe(1);
+    expect(announced).toBe("v0.4.2");
+  });
+  test("notifies from a fresh newer cache checked for another local version", async () => {
+    await fs.writeFile(cachePath, JSON.stringify({ checkedAt: 1_000, outcome: "success", version: "v0.4.2", checkedForVersion: "0.3.1" }));
+    let announced = "";
+    await checkForUpdates(config({ fetch: async () => { throw new Error("network"); }, onNewerRelease: (version) => { announced = version; } }));
+    expect(announced).toBe("v0.4.2");
+  });
+  test("suppresses a same-local current cache and fresh failures", async () => {
+    await fs.writeFile(cachePath, JSON.stringify({ checkedAt: 2_000, outcome: "success", version: "0.3.2", checkedForVersion: "0.3.2" }));
     let calls = 0;
     await checkForUpdates(config({ fetch: async () => { calls++; throw new Error("network"); } }));
     expect(calls).toBe(0);
-    await fs.writeFile(cachePath, JSON.stringify({ checkedAt: 1_000, outcome: "failure" }));
+    await fs.writeFile(cachePath, JSON.stringify({ checkedAt: 2_000, outcome: "success", version: "0.3.1", checkedForVersion: "0.3.2" }));
     await checkForUpdates(config({ fetch: async () => { calls++; throw new Error("network"); } }));
     expect(calls).toBe(0);
+    await fs.writeFile(cachePath, JSON.stringify({ checkedAt: 2_000, outcome: "failure" }));
+    await checkForUpdates(config({ fetch: async () => { calls++; throw new Error("network"); } }));
+    expect(calls).toBe(0);
+  });
+  test("refetches malformed cached versions", async () => {
+    let calls = 0;
+    await fs.writeFile(cachePath, JSON.stringify({ checkedAt: 1_000, outcome: "success", version: "not-a-version", checkedForVersion: "0.3.2" }));
+    await checkForUpdates(config({ fetch: async () => { calls++; return new Response(JSON.stringify({ tag_name: "0.3.2" }), { status: 200 }); } }));
+    await fs.writeFile(cachePath, JSON.stringify({ checkedAt: 1_000, outcome: "success", version: "0.3.3", checkedForVersion: "bad" }));
+    await checkForUpdates(config({ fetch: async () => { calls++; return new Response(JSON.stringify({ tag_name: "0.3.2" }), { status: 200 }); } }));
+    expect(calls).toBe(2);
   });
   test("fetches stale release and announces newer versions", async () => {
     let announced = "";


### PR DESCRIPTION
## Summary

- scope successful update-check caches to the PiTTy version that performed the check
- revalidate legacy or previous-version cache entries once after an upgrade
- replay a cached newer-release notification without another GitHub request
- keep the existing 24-hour network throttle for same-version and failed checks
- prepare v0.4.3

## Root cause

PiTTy returned early for every cache younger than 24 hours. The reported machine had a six-hour-old successful cache for `v0.3.3`, so startup never requested the now-current release and never reached the toast callback.

## Validation

- deterministic stale-cache reproduction: before fix `calls=0`, no announcement; after fix `calls=1`, announcement `v0.4.2`
- `npm run typecheck`
- `npm run test:unit` — 84 passed, 1 platform-specific skip
- `npm run test:ui` — 40 passed
- implementation review: PASS, no findings
- `git diff --check` and anti-pattern scan
